### PR TITLE
Ep/be 152 error refactoring for protocol

### DIFF
--- a/pallets/minterest-protocol/src/lib.rs
+++ b/pallets/minterest-protocol/src/lib.rs
@@ -96,10 +96,6 @@ decl_error! {
 		/// Repay was blocked due to Controller rejection.
 		RepayBorrowControllerRejection,
 
-		/// Pool not found.
-		PoolNotFound,
-
-
 		/// Transaction with zero balance is not allowed.
 		ZeroBalanceTransaction,
 
@@ -270,7 +266,10 @@ decl_module! {
 		#[weight = 10_000]
 		pub fn enable_as_collateral(origin, pool_id: CurrencyId) -> DispatchResult {
 			let sender = ensure_signed(origin)?;
-			ensure!(<LiquidityPools<T>>::pool_exists(&pool_id), Error::<T>::PoolNotFound);
+			ensure!(
+				T::UnderlyingAssetId::get().contains(&pool_id),
+				Error::<T>::NotValidUnderlyingAssetId
+			);
 
 			ensure!(!<LiquidityPools<T>>::check_user_available_collateral(&sender, pool_id), Error::<T>::AlreadyCollateral);
 
@@ -288,7 +287,10 @@ decl_module! {
 		#[weight = 10_000]
 		pub fn disable_collateral(origin, pool_id: CurrencyId) -> DispatchResult {
 			let sender = ensure_signed(origin)?;
-			ensure!(<LiquidityPools<T>>::pool_exists(&pool_id), Error::<T>::PoolNotFound);
+			ensure!(
+				T::UnderlyingAssetId::get().contains(&pool_id),
+				Error::<T>::NotValidUnderlyingAssetId
+			);
 
 			ensure!(<LiquidityPools<T>>::check_user_available_collateral(&sender, pool_id), Error::<T>::AlreadyDisabledCollateral);
 
@@ -363,7 +365,8 @@ impl<T: Trait> Module<T> {
 
 		<Controller<T>>::accrue_interest_rate(underlying_asset_id).map_err(|_| Error::<T>::AccrueInterestFailed)?;
 
-		let wrapped_id = <Controller<T>>::get_wrapped_id_by_underlying_asset_id(&underlying_asset_id)?;
+		let wrapped_id = <Controller<T>>::get_wrapped_id_by_underlying_asset_id(&underlying_asset_id)
+			.map_err(|_| Error::<T>::NotValidUnderlyingAssetId)?;
 
 		let wrapped_amount = match (underlying_amount, wrapped_amount, all_assets) {
 			(0, 0, true) => {

--- a/pallets/minterest-protocol/src/lib.rs
+++ b/pallets/minterest-protocol/src/lib.rs
@@ -78,9 +78,6 @@ decl_error! {
 		/// Number overflow in calculation.
 		NumOverflow,
 
-		/// The block number in the pool is equal to the current block number.
-		PoolNotFresh,
-
 		/// An internal failure occurred in the execution of the Accrue Interest function.
 		AccrueInterestFailed,
 
@@ -487,14 +484,6 @@ impl<T: Trait> Module<T> {
 		// Fail if repayBorrow not allowed
 		<Controller<T>>::repay_borrow_allowed(underlying_asset_id, &who, repay_amount)
 			.map_err(|_| Error::<T>::RepayBorrowControllerRejection)?;
-
-		// Verify pool's block number equals current block number
-		let current_block_number = <frame_system::Module<T>>::block_number();
-		let accrual_block_number_previous = <Controller<T>>::controller_dates(underlying_asset_id).timestamp;
-		ensure!(
-			current_block_number == accrual_block_number_previous,
-			Error::<T>::PoolNotFresh
-		);
 
 		// Fetch the amount the borrower owes, with accumulated interest
 		let account_borrows = <Controller<T>>::borrow_balance_stored(&borrower, underlying_asset_id)

--- a/pallets/minterest-protocol/src/tests.rs
+++ b/pallets/minterest-protocol/src/tests.rs
@@ -516,7 +516,7 @@ fn enable_as_collateral_should_work() {
 
 		assert_noop!(
 			TestProtocol::enable_as_collateral(alice(), CurrencyId::MDOT),
-			Error::<Test>::PoolNotFound
+			Error::<Test>::NotValidUnderlyingAssetId
 		);
 	});
 }
@@ -552,7 +552,7 @@ fn disable_collateral_should_work() {
 
 		assert_noop!(
 			TestProtocol::disable_collateral(alice(), CurrencyId::MDOT),
-			Error::<Test>::PoolNotFound
+			Error::<Test>::NotValidUnderlyingAssetId
 		);
 	});
 }


### PR DESCRIPTION
**Description:**

Change available_underlying_asset_id checking in mintrest-protocol pallet from PoolNotFound to NotValidunderlyingAssetId.
Refactor tests for that functions.
Remove PoolNotFresh checking form fn do_repay().
