### PR TITLE
Ep/be 154 controller rafactoring exchange rate borrow stored

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -235,7 +235,6 @@ fn testnet_genesis(
 					Pool {
 						total_borrowed: Balance::zero(),
 						borrow_index: FixedU128::one(),
-						current_exchange_rate: FixedU128::one(),
 						total_insurance: Balance::zero(),
 					},
 				),
@@ -244,7 +243,6 @@ fn testnet_genesis(
 					Pool {
 						total_borrowed: Balance::zero(),
 						borrow_index: FixedU128::one(),
-						current_exchange_rate: FixedU128::one(),
 						total_insurance: Balance::zero(),
 					},
 				),
@@ -253,7 +251,6 @@ fn testnet_genesis(
 					Pool {
 						total_borrowed: Balance::zero(),
 						borrow_index: FixedU128::one(),
-						current_exchange_rate: FixedU128::one(),
 						total_insurance: Balance::zero(),
 					},
 				),
@@ -262,7 +259,6 @@ fn testnet_genesis(
 					Pool {
 						total_borrowed: Balance::zero(),
 						borrow_index: FixedU128::one(),
-						current_exchange_rate: FixedU128::one(),
 						total_insurance: Balance::zero(),
 					},
 				),

--- a/pallets/controller/src/lib.rs
+++ b/pallets/controller/src/lib.rs
@@ -405,40 +405,40 @@ impl<T: Trait> Module<T> {
 		Ok(())
 	}
 
-	/// Converts a specified number of underlying assets into wrapped tokens.
-	/// The calculation is based on the exchange rate.
-	///
-	/// - `underlying_asset_id`: CurrencyId of underlying assets to be converted to wrapped tokens.
-	/// - `underlying_amount`: The amount of underlying assets to be converted to wrapped tokens.
-	/// Returns `wrapped_amount = underlying_amount / exchange_rate`
-	pub fn convert_to_wrapped(underlying_asset_id: CurrencyId, underlying_amount: Balance) -> BalanceResult {
-		let exchange_rate = Self::get_exchange_rate(underlying_asset_id)?;
-
-		let wrapped_amount = Rate::from_inner(underlying_amount)
-			.checked_div(&exchange_rate)
-			.map(|x| x.into_inner())
-			.ok_or(Error::<T>::NumOverflow)?;
-
-		Ok(wrapped_amount)
-	}
-
-	/// Converts a specified number of wrapped tokens into underlying assets.
-	/// The calculation is based on the exchange rate.
-	///
-	/// - `wrapped_id`: CurrencyId of the wrapped tokens to be converted to underlying assets.
-	/// - `wrapped_amount`: The amount of wrapped tokens to be converted to underlying assets.
-	/// Returns `underlying_amount = wrapped_amount * exchange_rate`
-	pub fn convert_from_wrapped(wrapped_id: CurrencyId, wrapped_amount: Balance) -> BalanceResult {
-		let underlying_asset_id = Self::get_underlying_asset_id_by_wrapped_id(&wrapped_id)?;
-		let exchange_rate = Self::get_exchange_rate(underlying_asset_id)?;
-
-		let underlying_amount = Rate::from_inner(wrapped_amount)
-			.checked_mul(&exchange_rate)
-			.map(|x| x.into_inner())
-			.ok_or(Error::<T>::NumOverflow)?;
-
-		Ok(underlying_amount)
-	}
+	// /// Converts a specified number of underlying assets into wrapped tokens.
+	// /// The calculation is based on the exchange rate.
+	// ///
+	// /// - `underlying_asset_id`: CurrencyId of underlying assets to be converted to wrapped tokens.
+	// /// - `underlying_amount`: The amount of underlying assets to be converted to wrapped tokens.
+	// /// Returns `wrapped_amount = underlying_amount / exchange_rate`
+	// pub fn convert_to_wrapped(underlying_asset_id: CurrencyId, underlying_amount: Balance) -> BalanceResult {
+	// 	let exchange_rate = Self::get_exchange_rate(underlying_asset_id)?;
+	//
+	// 	let wrapped_amount = Rate::from_inner(underlying_amount)
+	// 		.checked_div(&exchange_rate)
+	// 		.map(|x| x.into_inner())
+	// 		.ok_or(Error::<T>::NumOverflow)?;
+	//
+	// 	Ok(wrapped_amount)
+	// }
+	//
+	// /// Converts a specified number of wrapped tokens into underlying assets.
+	// /// The calculation is based on the exchange rate.
+	// ///
+	// /// - `wrapped_id`: CurrencyId of the wrapped tokens to be converted to underlying assets.
+	// /// - `wrapped_amount`: The amount of wrapped tokens to be converted to underlying assets.
+	// /// Returns `underlying_amount = wrapped_amount * exchange_rate`
+	// pub fn convert_from_wrapped(wrapped_id: CurrencyId, wrapped_amount: Balance) -> BalanceResult {
+	// 	let underlying_asset_id = Self::get_underlying_asset_id_by_wrapped_id(&wrapped_id)?;
+	// 	let exchange_rate = Self::get_exchange_rate(underlying_asset_id)?;
+	//
+	// 	let underlying_amount = Rate::from_inner(wrapped_amount)
+	// 		.checked_mul(&exchange_rate)
+	// 		.map(|x| x.into_inner())
+	// 		.ok_or(Error::<T>::NumOverflow)?;
+	//
+	// 	Ok(underlying_amount)
+	// }
 
 	/// Return the borrow balance of account based on stored data.
 	///

--- a/pallets/controller/src/lib.rs
+++ b/pallets/controller/src/lib.rs
@@ -405,41 +405,6 @@ impl<T: Trait> Module<T> {
 		Ok(())
 	}
 
-	// /// Converts a specified number of underlying assets into wrapped tokens.
-	// /// The calculation is based on the exchange rate.
-	// ///
-	// /// - `underlying_asset_id`: CurrencyId of underlying assets to be converted to wrapped tokens.
-	// /// - `underlying_amount`: The amount of underlying assets to be converted to wrapped tokens.
-	// /// Returns `wrapped_amount = underlying_amount / exchange_rate`
-	// pub fn convert_to_wrapped(underlying_asset_id: CurrencyId, underlying_amount: Balance) -> BalanceResult {
-	// 	let exchange_rate = Self::get_exchange_rate(underlying_asset_id)?;
-	//
-	// 	let wrapped_amount = Rate::from_inner(underlying_amount)
-	// 		.checked_div(&exchange_rate)
-	// 		.map(|x| x.into_inner())
-	// 		.ok_or(Error::<T>::NumOverflow)?;
-	//
-	// 	Ok(wrapped_amount)
-	// }
-	//
-	// /// Converts a specified number of wrapped tokens into underlying assets.
-	// /// The calculation is based on the exchange rate.
-	// ///
-	// /// - `wrapped_id`: CurrencyId of the wrapped tokens to be converted to underlying assets.
-	// /// - `wrapped_amount`: The amount of wrapped tokens to be converted to underlying assets.
-	// /// Returns `underlying_amount = wrapped_amount * exchange_rate`
-	// pub fn convert_from_wrapped(wrapped_id: CurrencyId, wrapped_amount: Balance) -> BalanceResult {
-	// 	let underlying_asset_id = Self::get_underlying_asset_id_by_wrapped_id(&wrapped_id)?;
-	// 	let exchange_rate = Self::get_exchange_rate(underlying_asset_id)?;
-	//
-	// 	let underlying_amount = Rate::from_inner(wrapped_amount)
-	// 		.checked_mul(&exchange_rate)
-	// 		.map(|x| x.into_inner())
-	// 		.ok_or(Error::<T>::NumOverflow)?;
-	//
-	// 	Ok(underlying_amount)
-	// }
-
 	/// Return the borrow balance of account based on stored data.
 	///
 	/// - `who`: the address whose balance should be calculated.
@@ -494,11 +459,11 @@ impl<T: Trait> Module<T> {
 
 		// For each tokens the account is in
 		for asset in m_tokens_ids.into_iter() {
-			let underlying_asset = Self::get_underlying_asset_id_by_wrapped_id(&asset)?;
+			let underlying_asset = <LiquidityPools<T>>::get_underlying_asset_id_by_wrapped_id(&asset)?;
 
 			// Read the balances and exchange rate from the cToken
 			let borrow_balance = Self::borrow_balance_stored(account, underlying_asset)?;
-			let exchange_rate = Self::get_exchange_rate(underlying_asset)?;
+			let exchange_rate = <LiquidityPools<T>>::get_exchange_rate(underlying_asset)?;
 			let collateral_factor = Self::get_collateral_factor(underlying_asset);
 
 			// Get the normalized price of the asset.
@@ -679,53 +644,6 @@ impl<T: Trait> Module<T> {
 
 // Private methods
 impl<T: Trait> Module<T> {
-	// /// Calculates the exchange rate from the underlying to the mToken.
-	// /// This function does not accrue interest before calculating the exchange rate.
-	// pub fn get_exchange_rate(underlying_asset_id: CurrencyId) -> RateResult {
-	// 	let wrapped_asset_id = Self::get_wrapped_id_by_underlying_asset_id(&underlying_asset_id)?;
-	// 	// The total amount of cash the market has
-	// 	let total_cash = <LiquidityPools<T>>::get_pool_available_liquidity(underlying_asset_id);
-	//
-	// 	// Total number of tokens in circulation
-	// 	let total_supply = T::MultiCurrency::total_issuance(wrapped_asset_id);
-	//
-	// 	let total_insurance = <LiquidityPools<T>>::get_pool_total_insurance(underlying_asset_id);
-	//
-	// 	let total_borrowed = <LiquidityPools<T>>::get_pool_total_borrowed(underlying_asset_id);
-	//
-	// 	let current_exchange_rate =
-	// 		Self::calculate_exchange_rate(total_cash, total_supply, total_insurance, total_borrowed)?;
-	// 	// FIXME: can be removed.
-	// 	<LiquidityPools<T>>::set_current_exchange_rate(underlying_asset_id, current_exchange_rate)?;
-	//
-	// 	Ok(current_exchange_rate)
-	// }
-	//
-	// /// Calculates the exchange rate from the underlying to the mToken.
-	// fn calculate_exchange_rate(
-	// 	total_cash: Balance,
-	// 	total_supply: Balance,
-	// 	total_insurance: Balance,
-	// 	total_borrowed: Balance,
-	// ) -> RateResult {
-	// 	let rate = match total_supply.cmp(&Balance::zero()) {
-	// 		// If there are no tokens minted: exchangeRate = InitialExchangeRate.
-	// 		Ordering::Equal => T::InitialExchangeRate::get(),
-	// 		// Otherwise: exchange_rate = (total_cash - total_insurance + total_borrowed) / total_supply
-	// 		_ => {
-	// 			let cash_plus_borrows = total_cash.checked_add(total_borrowed).ok_or(Error::<T>::NumOverflow)?;
-	//
-	// 			let cash_plus_borrows_minus_insurance = cash_plus_borrows
-	// 				.checked_sub(total_insurance)
-	// 				.ok_or(Error::<T>::NumOverflow)?;
-	//
-	// 			Rate::saturating_from_rational(cash_plus_borrows_minus_insurance, total_supply)
-	// 		}
-	// 	};
-	//
-	// 	Ok(rate)
-	// }
-
 	/// Calculates the current borrow rate per block.
 	fn calculate_borrow_interest_rate(underlying_asset_id: CurrencyId, utilization_rate: Rate) -> RateResult {
 		let kink = Self::controller_dates(underlying_asset_id).kink;
@@ -889,26 +807,6 @@ impl<T: Trait> Module<T> {
 			.ok_or(Error::<T>::NumOverflow)?;
 		Ok(result)
 	}
-
-	// pub fn get_wrapped_id_by_underlying_asset_id(asset_id: &CurrencyId) -> CurrencyIdResult {
-	// 	match asset_id {
-	// 		CurrencyId::DOT => Ok(CurrencyId::MDOT),
-	// 		CurrencyId::KSM => Ok(CurrencyId::MKSM),
-	// 		CurrencyId::BTC => Ok(CurrencyId::MBTC),
-	// 		CurrencyId::ETH => Ok(CurrencyId::METH),
-	// 		_ => Err(Error::<T>::NotValidUnderlyingAssetId.into()),
-	// 	}
-	// }
-	//
-	// pub fn get_underlying_asset_id_by_wrapped_id(wrapped_id: &CurrencyId) -> CurrencyIdResult {
-	// 	match wrapped_id {
-	// 		CurrencyId::MDOT => Ok(CurrencyId::DOT),
-	// 		CurrencyId::MKSM => Ok(CurrencyId::KSM),
-	// 		CurrencyId::MBTC => Ok(CurrencyId::BTC),
-	// 		CurrencyId::METH => Ok(CurrencyId::ETH),
-	// 		_ => Err(Error::<T>::NotValidWrappedTokenId.into()),
-	// 	}
-	// }
 }
 
 // Getters for Controller Data

--- a/pallets/controller/src/mock.rs
+++ b/pallets/controller/src/mock.rs
@@ -206,7 +206,6 @@ impl ExtBuilder {
 			Pool {
 				total_borrowed,
 				borrow_index: Rate::saturating_from_rational(1, 1),
-				current_exchange_rate: Rate::from_inner(1),
 				total_insurance: Balance::zero(),
 			},
 		));
@@ -221,7 +220,6 @@ impl ExtBuilder {
 			Pool {
 				total_borrowed: Balance::zero(),
 				borrow_index: Rate::saturating_from_rational(1, 1),
-				current_exchange_rate: Rate::from_inner(1),
 				total_insurance,
 			},
 		));
@@ -234,7 +232,6 @@ impl ExtBuilder {
 			Pool {
 				total_borrowed: Balance::zero(),
 				borrow_index: Rate::saturating_from_rational(2, 1),
-				current_exchange_rate: Rate::saturating_from_rational(1, 1),
 				total_insurance: Balance::zero(),
 			},
 		));

--- a/pallets/controller/src/mock.rs
+++ b/pallets/controller/src/mock.rs
@@ -106,12 +106,15 @@ impl orml_currencies::Trait for Runtime {
 
 parameter_types! {
 	pub const LiquidityPoolsModuleId: ModuleId = ModuleId(*b"min/pool");
+	pub const InitialExchangeRate: Rate = Rate::from_inner(1_000_000_000_000_000_000);
+
 }
 
 impl liquidity_pools::Trait for Runtime {
 	type Event = TestEvent;
 	type MultiCurrency = orml_tokens::Module<Runtime>;
 	type ModuleId = LiquidityPoolsModuleId;
+	type InitialExchangeRate = InitialExchangeRate;
 }
 
 impl oracle::Trait for Runtime {
@@ -128,7 +131,6 @@ impl accounts::Trait for Runtime {
 }
 
 parameter_types! {
-	pub const InitialExchangeRate: Rate = Rate::from_inner(1_000_000_000_000_000_000);
 	pub const BlocksPerYear: u128 = 5256000u128;
 	pub MTokensId: Vec<CurrencyId> = vec![
 			CurrencyId::MDOT,
@@ -146,7 +148,6 @@ parameter_types! {
 
 impl Trait for Runtime {
 	type Event = TestEvent;
-	type InitialExchangeRate = InitialExchangeRate;
 	type MTokensId = MTokensId;
 	type BlocksPerYear = BlocksPerYear;
 	type UnderlyingAssetId = UnderlyingAssetId;

--- a/pallets/controller/src/tests.rs
+++ b/pallets/controller/src/tests.rs
@@ -105,91 +105,6 @@ fn accrue_interest_should_not_work() {
 }
 
 #[test]
-fn convert_to_wrapped_should_work() {
-	ExtBuilder::default()
-		.user_balance(ALICE, CurrencyId::DOT, ONE_HUNDRED)
-		.user_balance(ALICE, CurrencyId::MDOT, ONE_HUNDRED)
-		.pool_total_borrowed(CurrencyId::DOT, 40)
-		.build()
-		.execute_with(|| {
-			// exchange_rate = 40 / 100 = 0.4
-			assert_eq!(Controller::convert_to_wrapped(CurrencyId::DOT, 10), Ok(25));
-
-			// Overflow in calculation: wrapped_amount = max_value() / exchange_rate,
-			// when exchange_rate < 1
-			assert_err!(
-				Controller::convert_to_wrapped(CurrencyId::DOT, Balance::max_value()),
-				Error::<Runtime>::NumOverflow
-			);
-		});
-}
-
-#[test]
-fn convert_from_wrapped_should_work() {
-	ExtBuilder::default()
-		.user_balance(ALICE, CurrencyId::DOT, ONE_HUNDRED)
-		.user_balance(ALICE, CurrencyId::MDOT, ONE_HUNDRED)
-		.user_balance(ALICE, CurrencyId::MBTC, 1)
-		.pool_balance(CurrencyId::BTC, 100)
-		.pool_total_borrowed(CurrencyId::DOT, 40)
-		.build()
-		.execute_with(|| {
-			// underlying_amount = 10 * 0.4 = 4
-			assert_eq!(Controller::convert_from_wrapped(CurrencyId::MDOT, 10), Ok(4));
-
-			// Overflow in calculation: underlying_amount = max_value() * exchange_rate
-			assert_err!(
-				Controller::convert_from_wrapped(CurrencyId::MBTC, Balance::max_value()),
-				Error::<Runtime>::NumOverflow
-			);
-		});
-}
-
-#[test]
-fn calculate_exchange_rate_should_work() {
-	ExtBuilder::default().build().execute_with(|| {
-		// exchange_rate = (102 - 2 + 20) / 100 = 1.2
-		assert_eq!(
-			Controller::calculate_exchange_rate(102, 100, 2, 20),
-			Ok(Rate::saturating_from_rational(12, 10))
-		);
-		// If there are no tokens minted: exchangeRate = InitialExchangeRate = 1.0
-		assert_eq!(
-			Controller::calculate_exchange_rate(102, 0, 2, 0),
-			Ok(Rate::saturating_from_rational(1, 1))
-		);
-
-		// Overflow in calculation: total_cash + total_borrowed
-		assert_noop!(
-			Controller::calculate_exchange_rate(Balance::max_value(), 100, 100, 100),
-			Error::<Runtime>::NumOverflow
-		);
-
-		// Overflow in calculation: cash_plus_borrows - total_insurance
-		assert_noop!(
-			Controller::calculate_exchange_rate(100, 100, Balance::max_value(), 100),
-			Error::<Runtime>::NumOverflow
-		);
-	});
-}
-
-#[test]
-fn get_exchange_rate_should_work() {
-	ExtBuilder::default()
-		.pool_balance(CurrencyId::DOT, dollars(100_u128))
-		.user_balance(ALICE, CurrencyId::MDOT, dollars(125_u128))
-		.pool_total_borrowed(CurrencyId::DOT, dollars(300_u128))
-		.build()
-		.execute_with(|| {
-			// exchange_rate = (100 - 0 + 300) / 125 = 3.2
-			assert_eq!(
-				Controller::get_exchange_rate(CurrencyId::DOT),
-				Ok(Rate::saturating_from_rational(32, 10))
-			);
-		});
-}
-
-#[test]
 fn calculate_borrow_interest_rate_should_work() {
 	ExtBuilder::default().build().execute_with(|| {
 		// Utilization rate less or equal than kink:
@@ -324,34 +239,6 @@ fn calculate_new_total_insurance_should_work() {
 		assert_noop!(
 			Controller::calculate_new_total_insurance(100, Rate::saturating_from_rational(1, 1), Balance::max_value()),
 			Error::<Runtime>::NumOverflow
-		);
-	});
-}
-
-#[test]
-fn get_wrapped_id_by_underlying_asset_id_should_work() {
-	ExtBuilder::default().build().execute_with(|| {
-		assert_eq!(
-			Controller::get_wrapped_id_by_underlying_asset_id(&CurrencyId::DOT),
-			Ok(CurrencyId::MDOT)
-		);
-		assert_noop!(
-			Controller::get_wrapped_id_by_underlying_asset_id(&CurrencyId::MDOT),
-			Error::<Runtime>::NotValidUnderlyingAssetId
-		);
-	});
-}
-
-#[test]
-fn get_underlying_asset_id_by_wrapped_id_should_work() {
-	ExtBuilder::default().build().execute_with(|| {
-		assert_eq!(
-			Controller::get_underlying_asset_id_by_wrapped_id(&CurrencyId::MDOT),
-			Ok(CurrencyId::DOT)
-		);
-		assert_noop!(
-			Controller::get_underlying_asset_id_by_wrapped_id(&CurrencyId::DOT),
-			Error::<Runtime>::NotValidWrappedTokenId
 		);
 	});
 }

--- a/pallets/integration-tests/src/lib.rs
+++ b/pallets/integration-tests/src/lib.rs
@@ -228,7 +228,6 @@ mod tests {
 				Pool {
 					total_borrowed,
 					borrow_index: Rate::saturating_from_rational(1, 1),
-					current_exchange_rate: Rate::one(),
 					total_insurance: Balance::zero(),
 				},
 			));
@@ -243,7 +242,6 @@ mod tests {
 				Pool {
 					total_borrowed: Balance::zero(),
 					borrow_index: Rate::saturating_from_rational(1, 1),
-					current_exchange_rate: Rate::one(),
 					total_insurance,
 				},
 			));
@@ -276,7 +274,6 @@ mod tests {
 				Pool {
 					total_borrowed: Balance::zero(),
 					borrow_index: Rate::saturating_from_rational(1, 1),
-					current_exchange_rate: Rate::one(),
 					total_insurance: Balance::zero(),
 				},
 			));

--- a/pallets/integration-tests/src/lib.rs
+++ b/pallets/integration-tests/src/lib.rs
@@ -126,12 +126,14 @@ mod tests {
 
 	parameter_types! {
 		pub const LiquidityPoolsModuleId: ModuleId = ModuleId(*b"min/pool");
+		pub const InitialExchangeRate: Rate = Rate::from_inner(1_000_000_000_000_000_000);
 	}
 
 	impl liquidity_pools::Trait for Test {
 		type Event = ();
 		type MultiCurrency = orml_tokens::Module<Test>;
 		type ModuleId = LiquidityPoolsModuleId;
+		type InitialExchangeRate = InitialExchangeRate;
 	}
 
 	impl minterest_protocol::Trait for Test {
@@ -140,7 +142,6 @@ mod tests {
 	}
 
 	parameter_types! {
-		pub const InitialExchangeRate: Rate = Rate::from_inner(1_000_000_000_000_000_000);
 		pub const BlocksPerYear: u128 = 5256000;
 		pub MTokensId: Vec<CurrencyId> = vec![
 			CurrencyId::MDOT,
@@ -152,7 +153,6 @@ mod tests {
 
 	impl controller::Trait for Test {
 		type Event = ();
-		type InitialExchangeRate = InitialExchangeRate;
 		type BlocksPerYear = BlocksPerYear;
 		type UnderlyingAssetId = UnderlyingAssetId;
 		type MTokensId = MTokensId;
@@ -228,7 +228,7 @@ mod tests {
 				Pool {
 					total_borrowed,
 					borrow_index: Rate::saturating_from_rational(1, 1),
-					current_exchange_rate: Rate::from_inner(1),
+					current_exchange_rate: Rate::one(),
 					total_insurance: Balance::zero(),
 				},
 			));
@@ -243,7 +243,7 @@ mod tests {
 				Pool {
 					total_borrowed: Balance::zero(),
 					borrow_index: Rate::saturating_from_rational(1, 1),
-					current_exchange_rate: Rate::from_inner(1),
+					current_exchange_rate: Rate::one(),
 					total_insurance,
 				},
 			));
@@ -276,7 +276,7 @@ mod tests {
 				Pool {
 					total_borrowed: Balance::zero(),
 					borrow_index: Rate::saturating_from_rational(1, 1),
-					current_exchange_rate: Rate::saturating_from_rational(1, 1),
+					current_exchange_rate: Rate::one(),
 					total_insurance: Balance::zero(),
 				},
 			));
@@ -463,7 +463,6 @@ mod tests {
 				assert_eq!(Currencies::free_balance(CurrencyId::MDOT, &ADMIN), BALANCE_ZERO);
 
 				// Checking DOT pool Storage params
-				assert_eq!(TestPools::pools(CurrencyId::DOT).current_exchange_rate, RATE_EQUALS_ONE);
 				assert_eq!(TestPools::pools(CurrencyId::DOT).borrow_index, RATE_EQUALS_ONE);
 				// Total insurance changed: 0 -> 100 000
 				let pool_total_insurance_block_number_0 =
@@ -548,7 +547,6 @@ mod tests {
 				);
 
 				// Checking DOT pool Storage params
-				assert_eq!(TestPools::pools(CurrencyId::DOT).current_exchange_rate, RATE_EQUALS_ONE);
 				assert_eq!(TestPools::pools(CurrencyId::DOT).borrow_index, RATE_EQUALS_ONE);
 				// Expected: 100 000
 				assert_eq!(
@@ -633,7 +631,6 @@ mod tests {
 				);
 
 				// Checking pool Storage params
-				assert_eq!(TestPools::pools(CurrencyId::DOT).current_exchange_rate, RATE_EQUALS_ONE);
 				assert_eq!(TestPools::pools(CurrencyId::DOT).borrow_index, RATE_EQUALS_ONE);
 				// Expected: 100 000
 				assert_eq!(
@@ -727,7 +724,6 @@ mod tests {
 				);
 
 				// Checking pool Storage params
-				assert_eq!(TestPools::pools(CurrencyId::DOT).current_exchange_rate, RATE_EQUALS_ONE);
 				// Expected: 1.000000004500000000
 				let pool_borrow_index_block_number_3: Rate =
 					Rate::saturating_from_rational(10_000_000_045u128, 10_000_000_000u128);
@@ -840,7 +836,6 @@ mod tests {
 					alice_m_dot_free_balance_block_number_1
 				);
 				// Checking pool Storage params
-				assert_eq!(TestPools::pools(CurrencyId::DOT).current_exchange_rate, RATE_EQUALS_ONE);
 				// Borrow_index changed: 1.000000004500000000 -> 1,000000006750000025
 				let pool_borrow_index_block_number_4 =
 					Rate::saturating_from_rational(1_000_000_006_750_000_025u128, 1_000_000_000_000_000_000u128);
@@ -906,8 +901,7 @@ mod tests {
 
 				// Check the underline amount before fn accrue_interest called
 				let alice_underlining_amount: Balance =
-					TestController::convert_from_wrapped(CurrencyId::MDOT, alice_m_dot_free_balance_block_number_1)
-						.unwrap();
+					TestPools::convert_from_wrapped(CurrencyId::MDOT, alice_m_dot_free_balance_block_number_1).unwrap();
 
 				System::set_block_number(5);
 
@@ -947,11 +941,6 @@ mod tests {
 				assert_eq!(Currencies::free_balance(CurrencyId::MDOT, &ALICE), BALANCE_ZERO);
 
 				// Checking pool Storage params
-				// Expected: 1,000000002531250008
-				assert_eq!(
-					TestPools::pools(CurrencyId::DOT).current_exchange_rate,
-					Rate::from_inner(1_000_000_002_531_250_008)
-				);
 				// Expected: 1,000000006750000025
 				assert_eq!(
 					TestPools::pools(CurrencyId::DOT).borrow_index,
@@ -1018,7 +1007,7 @@ mod tests {
 
 				// Calculate expected amount of wrapped tokens for Alice
 				let alice_expected_amount_wrapped_tokens =
-					TestController::convert_to_wrapped(CurrencyId::DOT, alice_deposited_amount).unwrap();
+					TestPools::convert_to_wrapped(CurrencyId::DOT, alice_deposited_amount).unwrap();
 
 				// Checking pool available liquidity increased by 60 000
 				assert_eq!(
@@ -1051,7 +1040,7 @@ mod tests {
 
 				// Calculate expected amount of wrapped tokens for Bob
 				let bob_expected_amount_wrapped_tokens =
-					TestController::convert_to_wrapped(CurrencyId::DOT, bob_deposited_amount).unwrap();
+					TestPools::convert_to_wrapped(CurrencyId::DOT, bob_deposited_amount).unwrap();
 
 				// Checking pool available liquidity increased by 60 000
 				assert_eq!(
@@ -1171,13 +1160,13 @@ mod tests {
 					ONE_HUNDRED - alice_deposited_amount_in_eth
 				);
 				let expected_amount_wrapped_tokens_in_dot =
-					TestController::convert_to_wrapped(CurrencyId::DOT, alice_deposited_amount_in_dot).unwrap();
+					TestPools::convert_to_wrapped(CurrencyId::DOT, alice_deposited_amount_in_dot).unwrap();
 				assert_eq!(
 					Currencies::free_balance(CurrencyId::MDOT, &ALICE),
 					expected_amount_wrapped_tokens_in_dot
 				);
 				let expected_amount_wrapped_tokens_in_eth =
-					TestController::convert_to_wrapped(CurrencyId::DOT, alice_deposited_amount_in_eth).unwrap();
+					TestPools::convert_to_wrapped(CurrencyId::DOT, alice_deposited_amount_in_eth).unwrap();
 				assert_eq!(
 					Currencies::free_balance(CurrencyId::METH, &ALICE),
 					expected_amount_wrapped_tokens_in_eth
@@ -1240,8 +1229,7 @@ mod tests {
 
 				assert_eq!(Currencies::free_balance(CurrencyId::MDOT, &ALICE), 0);
 				let expected_amount_wrapped_tokens_in_eth_summary = expected_amount_wrapped_tokens_in_eth
-					+ TestController::convert_to_wrapped(CurrencyId::DOT, alice_deposited_amount_in_eth_secondary)
-						.unwrap();
+					+ TestPools::convert_to_wrapped(CurrencyId::DOT, alice_deposited_amount_in_eth_secondary).unwrap();
 				assert_eq!(
 					Currencies::free_balance(CurrencyId::METH, &ALICE),
 					expected_amount_wrapped_tokens_in_eth_summary
@@ -1465,8 +1453,7 @@ mod tests {
 				// Alice redeem all DOTs
 				let alice_current_balance_amount_in_m_dot = Currencies::free_balance(CurrencyId::MDOT, &ALICE);
 				let alice_redeemed_amount_in_dot =
-					TestController::convert_from_wrapped(CurrencyId::MDOT, alice_current_balance_amount_in_m_dot)
-						.unwrap();
+					TestPools::convert_from_wrapped(CurrencyId::MDOT, alice_current_balance_amount_in_m_dot).unwrap();
 				assert_ok!(MinterestProtocol::redeem_underlying(
 					Origin::signed(ALICE),
 					CurrencyId::DOT,
@@ -1581,8 +1568,7 @@ mod tests {
 				let alice_current_balance_amount_in_m_dot = Currencies::free_balance(CurrencyId::MDOT, &ALICE);
 				// Expected exchange rate 1000000006581250024
 				let alice_redeemed_amount_in_dot =
-					TestController::convert_from_wrapped(CurrencyId::MDOT, alice_current_balance_amount_in_m_dot)
-						.unwrap();
+					TestPools::convert_from_wrapped(CurrencyId::MDOT, alice_current_balance_amount_in_m_dot).unwrap();
 				assert_ok!(MinterestProtocol::redeem_underlying(
 					Origin::signed(ALICE),
 					CurrencyId::DOT,
@@ -1679,13 +1665,13 @@ mod tests {
 					ONE_HUNDRED - alice_deposited_amount_in_eth
 				);
 				let expected_amount_wrapped_tokens_in_dot =
-					TestController::convert_to_wrapped(CurrencyId::DOT, alice_deposited_amount_in_dot).unwrap();
+					TestPools::convert_to_wrapped(CurrencyId::DOT, alice_deposited_amount_in_dot).unwrap();
 				assert_eq!(
 					Currencies::free_balance(CurrencyId::MDOT, &ALICE),
 					expected_amount_wrapped_tokens_in_dot
 				);
 				let expected_amount_wrapped_tokens_in_eth =
-					TestController::convert_to_wrapped(CurrencyId::DOT, alice_deposited_amount_in_eth).unwrap();
+					TestPools::convert_to_wrapped(CurrencyId::DOT, alice_deposited_amount_in_eth).unwrap();
 				assert_eq!(
 					Currencies::free_balance(CurrencyId::METH, &ALICE),
 					expected_amount_wrapped_tokens_in_eth
@@ -1749,8 +1735,7 @@ mod tests {
 
 				assert_eq!(Currencies::free_balance(CurrencyId::MDOT, &ALICE), 0);
 				let expected_amount_wrapped_tokens_in_eth_summary = expected_amount_wrapped_tokens_in_eth
-					+ TestController::convert_to_wrapped(CurrencyId::ETH, alice_deposited_amount_in_eth_secondary)
-						.unwrap();
+					+ TestPools::convert_to_wrapped(CurrencyId::ETH, alice_deposited_amount_in_eth_secondary).unwrap();
 				assert_eq!(
 					Currencies::free_balance(CurrencyId::METH, &ALICE),
 					expected_amount_wrapped_tokens_in_eth_summary
@@ -1962,8 +1947,7 @@ mod tests {
 				// Alice redeem all DOTs
 				let alice_current_balance_amount_in_m_dot = Currencies::free_balance(CurrencyId::MDOT, &ALICE);
 				let alice_redeemed_amount_in_dot =
-					TestController::convert_from_wrapped(CurrencyId::MDOT, alice_current_balance_amount_in_m_dot)
-						.unwrap();
+					TestPools::convert_from_wrapped(CurrencyId::MDOT, alice_current_balance_amount_in_m_dot).unwrap();
 				assert_ok!(MinterestProtocol::redeem(Origin::signed(ALICE), CurrencyId::DOT));
 
 				// Checking free balance DOT && ETH && BTC for user.
@@ -2065,8 +2049,7 @@ mod tests {
 				assert_ok!(MinterestProtocol::redeem(Origin::signed(ALICE), CurrencyId::DOT));
 
 				let alice_redeemed_amount_in_dot =
-					TestController::convert_from_wrapped(CurrencyId::MDOT, alice_current_balance_amount_in_m_dot)
-						.unwrap();
+					TestPools::convert_from_wrapped(CurrencyId::MDOT, alice_current_balance_amount_in_m_dot).unwrap();
 
 				// Checking pool available liquidity.
 				assert_eq!(
@@ -2587,7 +2570,7 @@ mod tests {
 					expected_amount_wrapped_tokens
 				);
 				assert_eq!(
-					TestController::get_exchange_rate(CurrencyId::DOT),
+					TestPools::get_exchange_rate(CurrencyId::DOT),
 					Ok(expected_exchange_rate_mock)
 				);
 			});
@@ -2620,7 +2603,7 @@ mod tests {
 					expected_amount_wrapped_tokens
 				);
 				assert_eq!(
-					TestController::get_exchange_rate(CurrencyId::DOT),
+					TestPools::get_exchange_rate(CurrencyId::DOT),
 					Ok(expected_exchange_rate_mock)
 				);
 			});
@@ -2663,7 +2646,7 @@ mod tests {
 					expected_amount_wrapped_tokens
 				);
 				assert_eq!(
-					TestController::get_exchange_rate(CurrencyId::DOT),
+					TestPools::get_exchange_rate(CurrencyId::DOT),
 					Ok(expected_exchange_rate_mock)
 				);
 			});
@@ -2706,7 +2689,7 @@ mod tests {
 					expected_amount_wrapped_tokens
 				);
 				assert_eq!(
-					TestController::get_exchange_rate(CurrencyId::DOT),
+					TestPools::get_exchange_rate(CurrencyId::DOT),
 					Ok(expected_exchange_rate_mock)
 				);
 			});
@@ -2757,7 +2740,7 @@ mod tests {
 				let expected_exchange_rate_mock_block_number_3 = Rate::from_inner(1000000002025000000);
 
 				assert_eq!(
-					TestController::get_exchange_rate(CurrencyId::DOT),
+					TestPools::get_exchange_rate(CurrencyId::DOT),
 					Ok(expected_exchange_rate_mock_block_number_3)
 				);
 
@@ -2786,7 +2769,7 @@ mod tests {
 					expected_amount_wrapped_tokens_bob
 				);
 				assert_eq!(
-					TestController::get_exchange_rate(CurrencyId::DOT),
+					TestPools::get_exchange_rate(CurrencyId::DOT),
 					Ok(expected_exchange_rate_mock_block_number_4)
 				);
 			});

--- a/pallets/liquidity-pools/src/lib.rs
+++ b/pallets/liquidity-pools/src/lib.rs
@@ -19,7 +19,6 @@ pub struct Pool {
 	pub total_borrowed: Balance,
 	/// Accumulator of the total earned interest rate since the opening of the pool
 	pub borrow_index: Rate,
-	pub current_exchange_rate: Rate, // FIXME. Delete and implement via RPC
 	pub total_insurance: Balance,
 }
 
@@ -100,11 +99,6 @@ type BalanceResult = result::Result<Balance, DispatchError>;
 
 // Setters for LiquidityPools
 impl<T: Trait> Module<T> {
-	pub fn set_current_exchange_rate(underlying_asset_id: CurrencyId, rate: Rate) -> DispatchResult {
-		Pools::mutate(underlying_asset_id, |r| r.current_exchange_rate = rate);
-		Ok(())
-	}
-
 	pub fn set_pool_total_borrowed(pool_id: CurrencyId, new_total_borrows: Balance) -> DispatchResult {
 		Pools::mutate(pool_id, |pool| pool.total_borrowed = new_total_borrows);
 		Ok(())

--- a/pallets/liquidity-pools/src/mock.rs
+++ b/pallets/liquidity-pools/src/mock.rs
@@ -104,12 +104,14 @@ pub type System = frame_system::Module<Test>;
 
 parameter_types! {
 	pub const LiquidityPoolsModuleId: ModuleId = ModuleId(*b"min/pool");
+	pub const InitialExchangeRate: Rate = Rate::from_inner(1_000_000_000_000_000_000);
 }
 
 impl Trait for Test {
 	type Event = TestEvent;
 	type MultiCurrency = orml_tokens::Module<Test>;
 	type ModuleId = LiquidityPoolsModuleId;
+	type InitialExchangeRate = InitialExchangeRate;
 }
 
 pub struct ExtBuilder {
@@ -133,6 +135,7 @@ pub type TestPools = Module<Test>;
 pub const ALICE: AccountId = 1;
 pub const DOLLARS: Balance = 1_000_000_000_000_000_000;
 pub const ONE_HUNDRED_DOLLARS: Balance = 100 * DOLLARS;
+pub const ONE_HUNDRED: Balance = 100;
 pub const TEN_THOUSAND: Balance = 10_000 * DOLLARS;
 
 impl ExtBuilder {
@@ -195,6 +198,19 @@ impl ExtBuilder {
 				borrow_index: Rate::default(),
 				current_exchange_rate: Rate::default(),
 				total_insurance: Balance::default(),
+			},
+		));
+		self
+	}
+
+	pub fn pool_total_borrowed(mut self, pool_id: CurrencyId, total_borrowed: Balance) -> Self {
+		self.pools.push((
+			pool_id,
+			Pool {
+				total_borrowed,
+				borrow_index: Rate::one(),
+				current_exchange_rate: Rate::one(),
+				total_insurance: Balance::zero(),
 			},
 		));
 		self

--- a/pallets/liquidity-pools/src/mock.rs
+++ b/pallets/liquidity-pools/src/mock.rs
@@ -155,7 +155,6 @@ impl ExtBuilder {
 		pool_id: CurrencyId,
 		total_borrowed: Balance,
 		borrow_index: Rate,
-		current_exchange_rate: Rate,
 		total_insurance: Balance,
 	) -> Self {
 		self.pools.push((
@@ -163,7 +162,6 @@ impl ExtBuilder {
 			Pool {
 				total_borrowed,
 				borrow_index,
-				current_exchange_rate,
 				total_insurance,
 			},
 		));
@@ -196,7 +194,6 @@ impl ExtBuilder {
 			Pool {
 				total_borrowed: Balance::default(),
 				borrow_index: Rate::default(),
-				current_exchange_rate: Rate::default(),
 				total_insurance: Balance::default(),
 			},
 		));
@@ -209,7 +206,6 @@ impl ExtBuilder {
 			Pool {
 				total_borrowed,
 				borrow_index: Rate::one(),
-				current_exchange_rate: Rate::one(),
 				total_insurance: Balance::zero(),
 			},
 		));

--- a/pallets/liquidity-pools/src/tests.rs
+++ b/pallets/liquidity-pools/src/tests.rs
@@ -3,8 +3,12 @@
 use super::*;
 use mock::*;
 
-use frame_support::{assert_noop, assert_ok};
+use frame_support::{assert_err, assert_noop, assert_ok};
 use sp_arithmetic::FixedPointNumber;
+
+fn dollars<T: Into<u128>>(d: T) -> Balance {
+	1_000_000_000_000_000_000_u128.saturating_mul(d.into())
+}
 
 #[test]
 fn set_current_exchange_rate_should_work() {
@@ -287,4 +291,117 @@ fn update_state_on_repay_should_work() {
 				Error::<Test>::NumOverflow
 			);
 		});
+}
+
+#[test]
+fn convert_to_wrapped_should_work() {
+	ExtBuilder::default()
+		.user_balance(ALICE, CurrencyId::DOT, ONE_HUNDRED)
+		.user_balance(ALICE, CurrencyId::MDOT, ONE_HUNDRED)
+		.pool_total_borrowed(CurrencyId::DOT, 40)
+		.build()
+		.execute_with(|| {
+			// exchange_rate = 40 / 100 = 0.4
+			assert_eq!(TestPools::convert_to_wrapped(CurrencyId::DOT, 10), Ok(25));
+
+			// Overflow in calculation: wrapped_amount = max_value() / exchange_rate,
+			// when exchange_rate < 1
+			assert_err!(
+				TestPools::convert_to_wrapped(CurrencyId::DOT, Balance::max_value()),
+				Error::<Test>::NumOverflow
+			);
+		});
+}
+
+#[test]
+fn convert_from_wrapped_should_work() {
+	ExtBuilder::default()
+		.user_balance(ALICE, CurrencyId::DOT, ONE_HUNDRED)
+		.user_balance(ALICE, CurrencyId::MDOT, ONE_HUNDRED)
+		.user_balance(ALICE, CurrencyId::MBTC, 1)
+		.pool_balance(CurrencyId::BTC, 100)
+		.pool_total_borrowed(CurrencyId::DOT, 40)
+		.build()
+		.execute_with(|| {
+			// underlying_amount = 10 * 0.4 = 4
+			assert_eq!(TestPools::convert_from_wrapped(CurrencyId::MDOT, 10), Ok(4));
+
+			// Overflow in calculation: underlying_amount = max_value() * exchange_rate
+			assert_err!(
+				TestPools::convert_from_wrapped(CurrencyId::MBTC, Balance::max_value()),
+				Error::<Test>::NumOverflow
+			);
+		});
+}
+
+#[test]
+fn calculate_exchange_rate_should_work() {
+	ExtBuilder::default().build().execute_with(|| {
+		// exchange_rate = (102 - 2 + 20) / 100 = 1.2
+		assert_eq!(
+			TestPools::calculate_exchange_rate(102, 100, 2, 20),
+			Ok(Rate::saturating_from_rational(12, 10))
+		);
+		// If there are no tokens minted: exchangeRate = InitialExchangeRate = 1.0
+		assert_eq!(
+			TestPools::calculate_exchange_rate(102, 0, 2, 0),
+			Ok(Rate::saturating_from_rational(1, 1))
+		);
+
+		// Overflow in calculation: total_cash + total_borrowed
+		assert_noop!(
+			TestPools::calculate_exchange_rate(Balance::max_value(), 100, 100, 100),
+			Error::<Test>::NumOverflow
+		);
+
+		// Overflow in calculation: cash_plus_borrows - total_insurance
+		assert_noop!(
+			TestPools::calculate_exchange_rate(100, 100, Balance::max_value(), 100),
+			Error::<Test>::NumOverflow
+		);
+	});
+}
+
+#[test]
+fn get_exchange_rate_should_work() {
+	ExtBuilder::default()
+		.pool_balance(CurrencyId::DOT, dollars(100_u128))
+		.user_balance(ALICE, CurrencyId::MDOT, dollars(125_u128))
+		.pool_total_borrowed(CurrencyId::DOT, dollars(300_u128))
+		.build()
+		.execute_with(|| {
+			// exchange_rate = (100 - 0 + 300) / 125 = 3.2
+			assert_eq!(
+				TestPools::get_exchange_rate(CurrencyId::DOT),
+				Ok(Rate::saturating_from_rational(32, 10))
+			);
+		});
+}
+
+#[test]
+fn get_wrapped_id_by_underlying_asset_id_should_work() {
+	ExtBuilder::default().build().execute_with(|| {
+		assert_eq!(
+			TestPools::get_wrapped_id_by_underlying_asset_id(&CurrencyId::DOT),
+			Ok(CurrencyId::MDOT)
+		);
+		assert_noop!(
+			TestPools::get_wrapped_id_by_underlying_asset_id(&CurrencyId::MDOT),
+			Error::<Test>::NotValidUnderlyingAssetId
+		);
+	});
+}
+
+#[test]
+fn get_underlying_asset_id_by_wrapped_id_should_work() {
+	ExtBuilder::default().build().execute_with(|| {
+		assert_eq!(
+			TestPools::get_underlying_asset_id_by_wrapped_id(&CurrencyId::MDOT),
+			Ok(CurrencyId::DOT)
+		);
+		assert_noop!(
+			TestPools::get_underlying_asset_id_by_wrapped_id(&CurrencyId::DOT),
+			Error::<Test>::NotValidWrappedTokenId
+		);
+	});
 }

--- a/pallets/liquidity-pools/src/tests.rs
+++ b/pallets/liquidity-pools/src/tests.rs
@@ -11,21 +11,6 @@ fn dollars<T: Into<u128>>(d: T) -> Balance {
 }
 
 #[test]
-fn set_current_exchange_rate_should_work() {
-	ExtBuilder::default().build().execute_with(|| {
-		// Set exchange_rate eq 1.2
-		assert_ok!(TestPools::set_current_exchange_rate(
-			CurrencyId::DOT,
-			Rate::saturating_from_rational(13, 10)
-		));
-		assert_eq!(
-			<Pools>::get(CurrencyId::DOT).current_exchange_rate,
-			Rate::saturating_from_rational(13, 10)
-		);
-	});
-}
-
-#[test]
 fn set_pool_total_borrowed_should_work() {
 	ExtBuilder::default().build().execute_with(|| {
 		// Set pool_total_borrowed eq 100 DOT

--- a/pallets/liquidity-pools/src/tests.rs
+++ b/pallets/liquidity-pools/src/tests.rs
@@ -114,13 +114,7 @@ fn get_pool_available_liquidity_should_work() {
 #[test]
 fn get_pool_total_borrowed_should_work() {
 	ExtBuilder::default()
-		.pool_with_params(
-			CurrencyId::DOT,
-			TEN_THOUSAND,
-			Rate::default(),
-			Rate::default(),
-			Balance::default(),
-		)
+		.pool_with_params(CurrencyId::DOT, TEN_THOUSAND, Rate::default(), Balance::default())
 		.build()
 		.execute_with(|| {
 			assert_eq!(TestPools::get_pool_total_borrowed(CurrencyId::DOT), TEN_THOUSAND);
@@ -130,13 +124,7 @@ fn get_pool_total_borrowed_should_work() {
 #[test]
 fn get_pool_total_insurance_should_work() {
 	ExtBuilder::default()
-		.pool_with_params(
-			CurrencyId::DOT,
-			Balance::default(),
-			Rate::default(),
-			Rate::default(),
-			TEN_THOUSAND,
-		)
+		.pool_with_params(CurrencyId::DOT, Balance::default(), Rate::default(), TEN_THOUSAND)
 		.build()
 		.execute_with(|| {
 			assert_eq!(TestPools::get_pool_total_insurance(CurrencyId::DOT), TEN_THOUSAND);
@@ -150,7 +138,6 @@ fn get_pool_borrow_index_should_work() {
 			CurrencyId::DOT,
 			Balance::default(),
 			Rate::saturating_from_rational(125, 100),
-			Rate::default(),
 			Balance::default(),
 		)
 		.build()

--- a/pallets/minterest-protocol/src/lib.rs
+++ b/pallets/minterest-protocol/src/lib.rs
@@ -194,7 +194,7 @@ decl_module! {
 		pub fn redeem_wrapped(origin, wrapped_id: CurrencyId, #[compact] wrapped_amount: Balance) {
 			with_transaction_result(|| {
 				let who = ensure_signed(origin)?;
-				let underlying_asset_id = <Controller<T>>::get_underlying_asset_id_by_wrapped_id(&wrapped_id).map_err(|_| Error::<T>::NotValidWrappedTokenId)?;
+				let underlying_asset_id = <LiquidityPools<T>>::get_underlying_asset_id_by_wrapped_id(&wrapped_id).map_err(|_| Error::<T>::NotValidWrappedTokenId)?;
 				let (underlying_amount, wrapped_id, _) = Self::do_redeem(&who, underlying_asset_id, Balance::zero(), wrapped_amount, false)?;
 				Self::deposit_event(RawEvent::Redeemed(who, underlying_asset_id, underlying_amount, wrapped_id, wrapped_amount));
 				Ok(())
@@ -275,7 +275,7 @@ decl_module! {
 			ensure!(!<LiquidityPools<T>>::check_user_available_collateral(&sender, pool_id), Error::<T>::AlreadyCollateral);
 
 			// If user does not have assets in the pool, then he cannot enable as collateral the pool.
-			let wrapped_id = <Controller<T>>::get_wrapped_id_by_underlying_asset_id(&pool_id)?;
+			let wrapped_id = <LiquidityPools<T>>::get_wrapped_id_by_underlying_asset_id(&pool_id)?;
 			let user_wrapped_balance = T::MultiCurrency::free_balance(wrapped_id, &sender);
 			ensure!(user_wrapped_balance > 0, Error::<T>::CanotBeEnabledAsCollateral);
 
@@ -292,9 +292,9 @@ decl_module! {
 
 			ensure!(<LiquidityPools<T>>::check_user_available_collateral(&sender, pool_id), Error::<T>::AlreadyDisabledCollateral);
 
-			let wrapped_id = <Controller<T>>::get_wrapped_id_by_underlying_asset_id(&pool_id)?;
+			let wrapped_id = <LiquidityPools<T>>::get_wrapped_id_by_underlying_asset_id(&pool_id)?;
 			let user_balance_wrapped_tokens = T::MultiCurrency::free_balance(wrapped_id, &sender);
-			let user_balance_disabled_asset = <Controller<T>>::convert_from_wrapped(wrapped_id, user_balance_wrapped_tokens)?;
+			let user_balance_disabled_asset = <LiquidityPools<T>>::convert_from_wrapped(wrapped_id, user_balance_wrapped_tokens)?;
 
 			// Check if the user will have enough collateral if he removes one of the collaterals.
 			let (_, shortfall) = <Controller<T>>::get_hypothetical_account_liquidity(&sender, pool_id, user_balance_disabled_asset, 0)?;
@@ -331,10 +331,10 @@ impl<T: Trait> Module<T> {
 		<Controller<T>>::deposit_allowed(underlying_asset_id, &who, underlying_amount)
 			.map_err(|_| Error::<T>::DepositControllerRejection)?;
 
-		let wrapped_id = <Controller<T>>::get_wrapped_id_by_underlying_asset_id(&underlying_asset_id)
+		let wrapped_id = <LiquidityPools<T>>::get_wrapped_id_by_underlying_asset_id(&underlying_asset_id)
 			.map_err(|_| Error::<T>::NotValidUnderlyingAssetId)?;
 
-		let wrapped_amount = <Controller<T>>::convert_to_wrapped(underlying_asset_id, underlying_amount)
+		let wrapped_amount = <LiquidityPools<T>>::convert_to_wrapped(underlying_asset_id, underlying_amount)
 			.map_err(|_| Error::<T>::NumOverflow)?;
 
 		T::MultiCurrency::transfer(
@@ -363,24 +363,24 @@ impl<T: Trait> Module<T> {
 
 		<Controller<T>>::accrue_interest_rate(underlying_asset_id).map_err(|_| Error::<T>::AccrueInterestFailed)?;
 
-		let wrapped_id = <Controller<T>>::get_wrapped_id_by_underlying_asset_id(&underlying_asset_id)?;
+		let wrapped_id = <LiquidityPools<T>>::get_wrapped_id_by_underlying_asset_id(&underlying_asset_id)?;
 
 		let wrapped_amount = match (underlying_amount, wrapped_amount, all_assets) {
 			(0, 0, true) => {
 				let total_wrapped_amount = T::MultiCurrency::free_balance(wrapped_id, &who);
 				ensure!(!total_wrapped_amount.is_zero(), Error::<T>::NumberOfWrappedTokensIsZero);
-				underlying_amount = <Controller<T>>::convert_from_wrapped(wrapped_id, total_wrapped_amount)
+				underlying_amount = <LiquidityPools<T>>::convert_from_wrapped(wrapped_id, total_wrapped_amount)
 					.map_err(|_| Error::<T>::NumOverflow)?;
 				total_wrapped_amount
 			}
 			(_, 0, false) => {
 				ensure!(underlying_amount > Balance::zero(), Error::<T>::ZeroBalanceTransaction);
-				<Controller<T>>::convert_to_wrapped(underlying_asset_id, underlying_amount)
+				<LiquidityPools<T>>::convert_to_wrapped(underlying_asset_id, underlying_amount)
 					.map_err(|_| Error::<T>::NumOverflow)?
 			}
 			_ => {
 				ensure!(wrapped_amount > Balance::zero(), Error::<T>::ZeroBalanceTransaction);
-				underlying_amount = <Controller<T>>::convert_from_wrapped(wrapped_id, wrapped_amount)
+				underlying_amount = <LiquidityPools<T>>::convert_from_wrapped(wrapped_id, wrapped_amount)
 					.map_err(|_| Error::<T>::NumOverflow)?;
 				wrapped_amount
 			}

--- a/pallets/minterest-protocol/src/mock.rs
+++ b/pallets/minterest-protocol/src/mock.rs
@@ -102,16 +102,17 @@ impl orml_currencies::Trait for Test {
 
 parameter_types! {
 	pub const LiquidityPoolsModuleId: ModuleId = ModuleId(*b"min/pool");
+	pub const InitialExchangeRate: Rate = Rate::from_inner(1_000_000_000_000_000_000);
 }
 
 impl liquidity_pools::Trait for Test {
 	type Event = TestEvent;
 	type MultiCurrency = orml_tokens::Module<Test>;
 	type ModuleId = LiquidityPoolsModuleId;
+	type InitialExchangeRate = InitialExchangeRate;
 }
 
 parameter_types! {
-	pub const InitialExchangeRate: Rate = Rate::from_inner(1_000_000_000_000_000_000);
 	pub const BlocksPerYear: u128 = 5256000;
 	pub MTokensId: Vec<CurrencyId> = vec![
 		CurrencyId::MDOT,
@@ -129,7 +130,6 @@ parameter_types! {
 
 impl controller::Trait for Test {
 	type Event = TestEvent;
-	type InitialExchangeRate = InitialExchangeRate;
 	type BlocksPerYear = BlocksPerYear;
 	type UnderlyingAssetId = UnderlyingAssetId;
 	type MTokensId = MTokensId;

--- a/pallets/minterest-protocol/src/mock.rs
+++ b/pallets/minterest-protocol/src/mock.rs
@@ -238,7 +238,6 @@ impl ExtBuilder {
 					Pool {
 						total_borrowed: Balance::zero(),
 						borrow_index: Rate::saturating_from_rational(1, 1),
-						current_exchange_rate: Rate::from_inner(1),
 						total_insurance: TEN_THOUSAND_DOLLARS,
 					},
 				),
@@ -247,7 +246,6 @@ impl ExtBuilder {
 					Pool {
 						total_borrowed: Balance::zero(),
 						borrow_index: Rate::saturating_from_rational(1, 1),
-						current_exchange_rate: Rate::from_inner(1),
 						total_insurance: TEN_THOUSAND_DOLLARS,
 					},
 				),
@@ -256,7 +254,6 @@ impl ExtBuilder {
 					Pool {
 						total_borrowed: Balance::zero(),
 						borrow_index: Rate::saturating_from_rational(1, 1),
-						current_exchange_rate: Rate::from_inner(1),
 						total_insurance: TEN_THOUSAND_DOLLARS,
 					},
 				),

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -275,14 +275,18 @@ impl orml_currencies::Trait for Runtime {
 	type WeightInfo = ();
 }
 
+parameter_types! {
+	pub const InitialExchangeRate: Rate = INITIAL_EXCHANGE_RATE;
+}
+
 impl liquidity_pools::Trait for Runtime {
 	type Event = Event;
 	type MultiCurrency = Currencies;
 	type ModuleId = LiquidityPoolsModuleId;
+	type InitialExchangeRate = InitialExchangeRate;
 }
 
 parameter_types! {
-	pub const InitialExchangeRate: Rate = INITIAL_EXCHANGE_RATE;
 	pub const BlocksPerYear: u128 = BLOCKS_PER_YEAR;
 	pub MTokensId: Vec<CurrencyId> = vec![
 		CurrencyId::MDOT,
@@ -294,7 +298,6 @@ parameter_types! {
 
 impl controller::Trait for Runtime {
 	type Event = Event;
-	type InitialExchangeRate = InitialExchangeRate;
 	type MTokensId = MTokensId;
 	type BlocksPerYear = BlocksPerYear;
 	type UnderlyingAssetId = UnderlyingAssetId;

--- a/types.json
+++ b/types.json
@@ -26,7 +26,6 @@
     "Pool": {
       "total_borrowed": "Balance",
       "borrow_index": "Rate",
-      "current_exchange_rate": "Rate",
       "total_insurance": "Balance"
     },
     "PoolUserData" : {


### PR DESCRIPTION
**Description:**

Replace fns convert_from_wrapped/convert_to_wrapped/get_exchange_rate/calculate_exchage_rate/get_underlying_by_wrapped/get_wrapped_by_underlying/ from controller to pool.
Remove field current_exchange_rate from  "pool" struct in liquidity-pools pallet.
Fix tests acoording to changes above.


**Changes in storage:**

liquidity-pools:
   stuct pools {
      ...
      current_exchange_rate - REMOVED
      ...
   }
