### PR TITLE
AL/BE-221. Fix pool insurance in tests.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3358,7 +3358,7 @@ dependencies = [
 
 [[package]]
 name = "minterest-chain"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "minterest-cli",
  "minterest-service",

--- a/pallets/controller/src/mock.rs
+++ b/pallets/controller/src/mock.rs
@@ -93,7 +93,7 @@ impl orml_tokens::Trait for Runtime {
 }
 
 parameter_types! {
-	pub const GetNativeCurrencyId: CurrencyId = CurrencyId::MINT;
+	pub const GetNativeCurrencyId: CurrencyId = CurrencyId::MNT;
 }
 
 type NativeCurrency = Currency<Runtime, GetNativeCurrencyId>;

--- a/pallets/integration-tests/src/lib.rs
+++ b/pallets/integration-tests/src/lib.rs
@@ -210,7 +210,7 @@ mod tests {
 				pool_id,
 				Pool {
 					total_borrowed,
-					borrow_index: Rate::saturating_from_rational(1, 1),
+					borrow_index: Rate::one(),
 					total_insurance: Balance::zero(),
 				},
 			));
@@ -244,7 +244,7 @@ mod tests {
 				pool_id,
 				Pool {
 					total_borrowed: Balance::zero(),
-					borrow_index: Rate::saturating_from_rational(1, 1),
+					borrow_index: Rate::one(),
 					total_insurance: Balance::zero(),
 				},
 			));

--- a/pallets/integration-tests/src/lib.rs
+++ b/pallets/integration-tests/src/lib.rs
@@ -217,20 +217,6 @@ mod tests {
 			self
 		}
 
-		pub fn pool_total_insurance(mut self, pool_id: CurrencyId, total_insurance: Balance) -> Self {
-			self.endowed_accounts
-				.push((TestPools::pools_account_id(), pool_id, total_insurance));
-			self.pools.push((
-				pool_id,
-				Pool {
-					total_borrowed: Balance::zero(),
-					borrow_index: Rate::saturating_from_rational(1, 1),
-					total_insurance,
-				},
-			));
-			self
-		}
-
 		pub fn pool_user_data(
 			mut self,
 			pool_id: CurrencyId,

--- a/pallets/integration-tests/src/lib.rs
+++ b/pallets/integration-tests/src/lib.rs
@@ -85,7 +85,7 @@ mod tests {
 	}
 
 	parameter_types! {
-	pub const GetNativeCurrencyId: CurrencyId = CurrencyId::MINT;
+	pub const GetNativeCurrencyId: CurrencyId = CurrencyId::MNT;
 	}
 
 	type NativeCurrency = Currency<Test, GetNativeCurrencyId>;

--- a/pallets/integration-tests/src/tests/controller_tests.rs
+++ b/pallets/integration-tests/src/tests/controller_tests.rs
@@ -87,7 +87,6 @@ mod tests {
 		ExtBuilder::default()
 			.user_balance(ALICE, CurrencyId::DOT, ONE_HUNDRED)
 			.pool_user_data(CurrencyId::DOT, ALICE, BALANCE_ZERO, RATE_ZERO, true, 0)
-			.pool_total_insurance(CurrencyId::DOT, BALANCE_ZERO)
 			.build()
 			.execute_with(|| {
 				// Alice deposit to DOT pool
@@ -149,7 +148,6 @@ mod tests {
 		ExtBuilder::default()
 			.user_balance(ALICE, CurrencyId::DOT, ONE_HUNDRED)
 			.pool_user_data(CurrencyId::DOT, ALICE, BALANCE_ZERO, RATE_ZERO, true, 0)
-			.pool_total_insurance(CurrencyId::DOT, BALANCE_ZERO)
 			.build()
 			.execute_with(|| {
 				// Alice deposit to DOT pool

--- a/pallets/integration-tests/src/tests/controller_tests.rs
+++ b/pallets/integration-tests/src/tests/controller_tests.rs
@@ -85,6 +85,7 @@ mod tests {
 	#[test]
 	fn set_insurance_factor_greater_than_zero() {
 		ExtBuilder::default()
+			.pool_initial(CurrencyId::DOT)
 			.user_balance(ALICE, CurrencyId::DOT, ONE_HUNDRED)
 			.pool_user_data(CurrencyId::DOT, ALICE, BALANCE_ZERO, RATE_ZERO, true, 0)
 			.build()
@@ -146,6 +147,7 @@ mod tests {
 	#[test]
 	fn set_insurance_factor_equal_zero() {
 		ExtBuilder::default()
+			.pool_initial(CurrencyId::DOT)
 			.user_balance(ALICE, CurrencyId::DOT, ONE_HUNDRED)
 			.pool_user_data(CurrencyId::DOT, ALICE, BALANCE_ZERO, RATE_ZERO, true, 0)
 			.build()

--- a/pallets/integration-tests/src/tests/liquidity_pools_tests.rs
+++ b/pallets/integration-tests/src/tests/liquidity_pools_tests.rs
@@ -11,7 +11,6 @@ mod tests {
 		ExtBuilder::default()
 			.user_balance(ALICE, CurrencyId::DOT, ONE_HUNDRED)
 			.pool_user_data(CurrencyId::DOT, ALICE, BALANCE_ZERO, RATE_ZERO, false, 0)
-			.pool_total_insurance(CurrencyId::DOT, BALANCE_ZERO)
 			.build()
 			.execute_with(|| {
 				// Alice deposit to DOT pool
@@ -44,7 +43,6 @@ mod tests {
 		ExtBuilder::default()
 			.user_balance(ALICE, CurrencyId::DOT, ONE_HUNDRED)
 			.pool_user_data(CurrencyId::DOT, ALICE, BALANCE_ZERO, RATE_ZERO, false, 0)
-			.pool_total_insurance(CurrencyId::DOT, ONE_HUNDRED)
 			.build()
 			.execute_with(|| {
 				// Alice deposit to DOT pool
@@ -77,7 +75,6 @@ mod tests {
 		ExtBuilder::default()
 			.user_balance(ALICE, CurrencyId::DOT, ONE_HUNDRED)
 			.pool_user_data(CurrencyId::DOT, ALICE, BALANCE_ZERO, RATE_ZERO, true, 0)
-			.pool_total_insurance(CurrencyId::DOT, BALANCE_ZERO)
 			.build()
 			.execute_with(|| {
 				// Alice deposit to DOT pool
@@ -120,7 +117,6 @@ mod tests {
 		ExtBuilder::default()
 			.user_balance(ALICE, CurrencyId::DOT, ONE_HUNDRED)
 			.pool_user_data(CurrencyId::DOT, ALICE, BALANCE_ZERO, RATE_ZERO, true, 0)
-			.pool_total_insurance(CurrencyId::DOT, ONE_HUNDRED)
 			.build()
 			.execute_with(|| {
 				// Alice deposit to DOT pool
@@ -165,7 +161,6 @@ mod tests {
 			.user_balance(BOB, CurrencyId::DOT, ONE_HUNDRED)
 			.pool_user_data(CurrencyId::DOT, ALICE, BALANCE_ZERO, RATE_ZERO, true, 0)
 			.pool_user_data(CurrencyId::DOT, BOB, BALANCE_ZERO, RATE_ZERO, true, 0)
-			.pool_total_insurance(CurrencyId::DOT, ONE_HUNDRED)
 			.build()
 			.execute_with(|| {
 				// Alice deposit to DOT pool

--- a/pallets/integration-tests/src/tests/liquidity_pools_tests.rs
+++ b/pallets/integration-tests/src/tests/liquidity_pools_tests.rs
@@ -7,7 +7,7 @@ mod tests {
 
 	// Function `get_exchange_rate + calculate_exchange_rate` scenario #1:
 	#[test]
-	fn get_exchange_rate_deposit_without_insurance() {
+	fn get_exchange_rate_deposit() {
 		ExtBuilder::default()
 			.user_balance(ALICE, CurrencyId::DOT, ONE_HUNDRED)
 			.pool_user_data(CurrencyId::DOT, ALICE, BALANCE_ZERO, RATE_ZERO, false, 0)
@@ -39,39 +39,7 @@ mod tests {
 
 	// Function `get_exchange_rate + calculate_exchange_rate` scenario #2:
 	#[test]
-	fn get_exchange_rate_deposit_with_pool_insurance() {
-		ExtBuilder::default()
-			.user_balance(ALICE, CurrencyId::DOT, ONE_HUNDRED)
-			.pool_user_data(CurrencyId::DOT, ALICE, BALANCE_ZERO, RATE_ZERO, false, 0)
-			.build()
-			.execute_with(|| {
-				// Alice deposit to DOT pool
-				let alice_deposited_amount = 40_000 * DOLLARS;
-				assert_ok!(MinterestProtocol::deposit_underlying(
-					Origin::signed(ALICE),
-					CurrencyId::DOT,
-					alice_deposited_amount
-				));
-
-				// Expected exchange rate && wrapped amount based on params after fn accrue_interest_rate called
-				let expected_amount_wrapped_tokens = 40_000 * DOLLARS;
-				let expected_exchange_rate_mock = Rate::one();
-
-				// Checking if real exchange rate && wrapped amount is equal to the expected
-				assert_eq!(
-					Currencies::free_balance(CurrencyId::MDOT, &ALICE),
-					expected_amount_wrapped_tokens
-				);
-				assert_eq!(
-					TestPools::get_exchange_rate(CurrencyId::DOT),
-					Ok(expected_exchange_rate_mock)
-				);
-			});
-	}
-
-	// Function `get_exchange_rate + calculate_exchange_rate` scenario #3:
-	#[test]
-	fn get_exchange_rate_deposit_and_borrow_without_insurance() {
+	fn get_exchange_rate_deposit_and_borrow() {
 		ExtBuilder::default()
 			.user_balance(ALICE, CurrencyId::DOT, ONE_HUNDRED)
 			.pool_user_data(CurrencyId::DOT, ALICE, BALANCE_ZERO, RATE_ZERO, true, 0)
@@ -111,51 +79,9 @@ mod tests {
 			});
 	}
 
-	// Function `get_exchange_rate + calculate_exchange_rate` scenario #4:
+	// Function `get_exchange_rate + calculate_exchange_rate` scenario #3:
 	#[test]
-	fn get_exchange_rate_deposit_and_borrow_with_insurance() {
-		ExtBuilder::default()
-			.user_balance(ALICE, CurrencyId::DOT, ONE_HUNDRED)
-			.pool_user_data(CurrencyId::DOT, ALICE, BALANCE_ZERO, RATE_ZERO, true, 0)
-			.build()
-			.execute_with(|| {
-				// Alice deposit to DOT pool
-				let alice_deposited_amount = 40_000 * DOLLARS;
-				assert_ok!(MinterestProtocol::deposit_underlying(
-					Origin::signed(ALICE),
-					CurrencyId::DOT,
-					alice_deposited_amount
-				));
-
-				System::set_block_number(2);
-
-				// Alice borrow from DOT pool
-				let alice_borrowed_amount_in_dot = 20_000 * DOLLARS;
-				assert_ok!(MinterestProtocol::borrow(
-					Origin::signed(ALICE),
-					CurrencyId::DOT,
-					alice_borrowed_amount_in_dot
-				));
-
-				// Expected exchange rate && wrapped amount based on params after fn accrue_interest_rate called
-				let expected_amount_wrapped_tokens = 40_000 * DOLLARS;
-				let expected_exchange_rate_mock = Rate::one();
-
-				// Checking if real exchange rate && wrapped amount is equal to the expected
-				assert_eq!(
-					Currencies::free_balance(CurrencyId::MDOT, &ALICE),
-					expected_amount_wrapped_tokens
-				);
-				assert_eq!(
-					TestPools::get_exchange_rate(CurrencyId::DOT),
-					Ok(expected_exchange_rate_mock)
-				);
-			});
-	}
-
-	// Function `get_exchange_rate + calculate_exchange_rate` scenario #5:
-	#[test]
-	fn get_exchange_rate_few_deposits_and_borrows_with_insurance() {
+	fn get_exchange_rate_few_deposits_and_borrows() {
 		ExtBuilder::default()
 			.user_balance(ALICE, CurrencyId::DOT, ONE_HUNDRED)
 			.user_balance(BOB, CurrencyId::DOT, ONE_HUNDRED)

--- a/pallets/integration-tests/src/tests/minterest_model_tests.rs
+++ b/pallets/integration-tests/src/tests/minterest_model_tests.rs
@@ -7,7 +7,7 @@ mod tests {
 
 	// Function `calculate_borrow_interest_rate + calculate_utilization_rate` scenario #1:
 	#[test]
-	fn calculate_borrow_interest_rate_deposit_without_insurance() {
+	fn calculate_borrow_interest_rate_deposit() {
 		ExtBuilder::default()
 			.user_balance(ALICE, CurrencyId::DOT, ONE_HUNDRED)
 			.pool_user_data(CurrencyId::DOT, ALICE, BALANCE_ZERO, RATE_ZERO, true, 0)
@@ -33,33 +33,7 @@ mod tests {
 
 	// Function `calculate_borrow_interest_rate + calculate_utilization_rate` scenario #2:
 	#[test]
-	fn calculate_borrow_interest_rate_deposit_with_pool_insurance() {
-		ExtBuilder::default()
-			.user_balance(ALICE, CurrencyId::DOT, ONE_HUNDRED)
-			.pool_user_data(CurrencyId::DOT, ALICE, BALANCE_ZERO, RATE_ZERO, true, 0)
-			.build()
-			.execute_with(|| {
-				// Alice deposit 40 DOT in pool
-				let alice_deposited_amount = 40_000 * DOLLARS;
-				assert_ok!(MinterestProtocol::deposit_underlying(
-					Origin::signed(ALICE),
-					CurrencyId::DOT,
-					alice_deposited_amount
-				));
-
-				// utilization_rate = 0 / (140_000 - 100_000 + 0) = 0 < 0.8
-				// borrow_rate = 0 * 0.000_000_009 + 0 = 0
-				let (borrow_rate, _) =
-					TestController::get_liquidity_pool_borrow_and_supply_rates(CurrencyId::DOT).unwrap_or_default();
-
-				// Checking if real borrow interest rate is equal to the expected
-				assert_eq!(Rate::zero(), borrow_rate);
-			});
-	}
-
-	// Function `calculate_borrow_interest_rate + calculate_utilization_rate` scenario #3:
-	#[test]
-	fn calculate_borrow_interest_rate_deposit_and_borrow_without_insurance() {
+	fn calculate_borrow_interest_rate_deposit_and_borrow() {
 		ExtBuilder::default()
 			.user_balance(ALICE, CurrencyId::DOT, ONE_HUNDRED)
 			.pool_user_data(CurrencyId::DOT, ALICE, BALANCE_ZERO, RATE_ZERO, true, 0)
@@ -95,47 +69,9 @@ mod tests {
 			});
 	}
 
-	// Function `calculate_borrow_interest_rate + calculate_utilization_rate` scenario #4:
+	// Function `calculate_borrow_interest_rate + calculate_utilization_rate` scenario #3:
 	#[test]
-	fn calculate_borrow_interest_rate_deposit_and_borrow_with_insurance() {
-		ExtBuilder::default()
-			.user_balance(ALICE, CurrencyId::DOT, ONE_HUNDRED)
-			.pool_user_data(CurrencyId::DOT, ALICE, BALANCE_ZERO, RATE_ZERO, true, 0)
-			.build()
-			.execute_with(|| {
-				// Alice deposit to DOT pool
-				let alice_deposited_amount = 40_000 * DOLLARS;
-				assert_ok!(MinterestProtocol::deposit_underlying(
-					Origin::signed(ALICE),
-					CurrencyId::DOT,
-					alice_deposited_amount
-				));
-
-				System::set_block_number(2);
-
-				// Alice borrow from DOT pool
-				let alice_borrowed_amount_in_dot = 20_000 * DOLLARS;
-				assert_ok!(MinterestProtocol::borrow(
-					Origin::signed(ALICE),
-					CurrencyId::DOT,
-					alice_borrowed_amount_in_dot
-				));
-
-				// utilization_rate = 20_000 / (120_000 - 100_000 + 20_000) = 0.5 < kink = 0.8
-				// borrow_rate = 0.5 * 0.000_000_009 + 0 = 45 * 10^(-10)
-				let expected_borrow_rate_mock = Rate::saturating_from_rational(45_u128, 10_000_000_000_u128);
-
-				let (borrow_rate, _) =
-					TestController::get_liquidity_pool_borrow_and_supply_rates(CurrencyId::DOT).unwrap_or_default();
-
-				// Checking if real borrow interest rate is equal to the expected
-				assert_eq!(expected_borrow_rate_mock, borrow_rate);
-			});
-	}
-
-	// Function `calculate_borrow_interest_rate + calculate_utilization_rate` scenario #5:
-	#[test]
-	fn calculate_borrow_interest_rate_few_deposits_and_borrows_with_insurance() {
+	fn calculate_borrow_interest_rate_few_deposits_and_borrows() {
 		ExtBuilder::default()
 			.user_balance(ALICE, CurrencyId::DOT, ONE_HUNDRED)
 			.user_balance(BOB, CurrencyId::DOT, ONE_HUNDRED)

--- a/pallets/integration-tests/src/tests/minterest_model_tests.rs
+++ b/pallets/integration-tests/src/tests/minterest_model_tests.rs
@@ -11,7 +11,6 @@ mod tests {
 		ExtBuilder::default()
 			.user_balance(ALICE, CurrencyId::DOT, ONE_HUNDRED)
 			.pool_user_data(CurrencyId::DOT, ALICE, BALANCE_ZERO, RATE_ZERO, true, 0)
-			.pool_total_insurance(CurrencyId::DOT, BALANCE_ZERO)
 			.build()
 			.execute_with(|| {
 				// Alice deposit 40 DOT in pool
@@ -38,7 +37,6 @@ mod tests {
 		ExtBuilder::default()
 			.user_balance(ALICE, CurrencyId::DOT, ONE_HUNDRED)
 			.pool_user_data(CurrencyId::DOT, ALICE, BALANCE_ZERO, RATE_ZERO, true, 0)
-			.pool_total_insurance(CurrencyId::DOT, ONE_HUNDRED)
 			.build()
 			.execute_with(|| {
 				// Alice deposit 40 DOT in pool
@@ -65,7 +63,6 @@ mod tests {
 		ExtBuilder::default()
 			.user_balance(ALICE, CurrencyId::DOT, ONE_HUNDRED)
 			.pool_user_data(CurrencyId::DOT, ALICE, BALANCE_ZERO, RATE_ZERO, true, 0)
-			.pool_total_insurance(CurrencyId::DOT, BALANCE_ZERO)
 			.build()
 			.execute_with(|| {
 				// Alice deposit to DOT pool
@@ -104,7 +101,6 @@ mod tests {
 		ExtBuilder::default()
 			.user_balance(ALICE, CurrencyId::DOT, ONE_HUNDRED)
 			.pool_user_data(CurrencyId::DOT, ALICE, BALANCE_ZERO, RATE_ZERO, true, 0)
-			.pool_total_insurance(CurrencyId::DOT, ONE_HUNDRED)
 			.build()
 			.execute_with(|| {
 				// Alice deposit to DOT pool
@@ -145,7 +141,6 @@ mod tests {
 			.user_balance(BOB, CurrencyId::DOT, ONE_HUNDRED)
 			.pool_user_data(CurrencyId::DOT, ALICE, BALANCE_ZERO, RATE_ZERO, true, 0)
 			.pool_user_data(CurrencyId::DOT, BOB, BALANCE_ZERO, RATE_ZERO, true, 0)
-			.pool_total_insurance(CurrencyId::DOT, ONE_HUNDRED)
 			.build()
 			.execute_with(|| {
 				// Alice deposit to DOT pool

--- a/pallets/integration-tests/src/tests/minterest_protocol_tests.rs
+++ b/pallets/integration-tests/src/tests/minterest_protocol_tests.rs
@@ -784,7 +784,6 @@ mod tests {
 				assert_ok!(MinterestProtocol::redeem(Origin::signed(ALICE), CurrencyId::DOT));
 
 				// Checking free balance DOT/MDOT && ETH/METH in pool.
-				// current_exchange_rate == 1000000221932654817
 				let expected_amount_redeemed_underlying_assets = 60000000136963397880000;
 				assert_eq!(
 					Currencies::free_balance(CurrencyId::DOT, &ALICE),

--- a/pallets/integration-tests/src/tests/minterest_protocol_tests.rs
+++ b/pallets/integration-tests/src/tests/minterest_protocol_tests.rs
@@ -131,6 +131,7 @@ mod tests {
 	#[test]
 	fn redeem_underlying_with_current_currency_borrowing() {
 		ExtBuilder::default()
+			.pool_initial(CurrencyId::DOT)
 			.user_balance(ADMIN, CurrencyId::DOT, ONE_HUNDRED)
 			.user_balance(ALICE, CurrencyId::DOT, ONE_HUNDRED)
 			.user_balance(ALICE, CurrencyId::ETH, ONE_HUNDRED)
@@ -195,7 +196,7 @@ mod tests {
 					expected_amount_wrapped_tokens_in_dot
 				);
 				let expected_amount_wrapped_tokens_in_eth =
-					TestPools::convert_to_wrapped(CurrencyId::DOT, alice_deposited_amount_in_eth).unwrap();
+					TestPools::convert_to_wrapped(CurrencyId::ETH, alice_deposited_amount_in_eth).unwrap();
 				assert_eq!(
 					Currencies::free_balance(CurrencyId::METH, &ALICE),
 					expected_amount_wrapped_tokens_in_eth
@@ -237,7 +238,7 @@ mod tests {
 				System::set_block_number(6);
 
 				// Alice redeem all DOTs
-				let expected_amount_redeemed_underlying_assets = 60000019601999999880000;
+				let expected_amount_redeemed_underlying_assets = 60_000_000_142_382_812_500_000;
 				assert_ok!(MinterestProtocol::redeem_underlying(
 					Origin::signed(ALICE),
 					CurrencyId::DOT,
@@ -258,7 +259,7 @@ mod tests {
 
 				assert_eq!(Currencies::free_balance(CurrencyId::MDOT, &ALICE), 0);
 				let expected_amount_wrapped_tokens_in_eth_summary = expected_amount_wrapped_tokens_in_eth
-					+ TestPools::convert_to_wrapped(CurrencyId::DOT, alice_deposited_amount_in_eth_secondary).unwrap();
+					+ TestPools::convert_to_wrapped(CurrencyId::ETH, alice_deposited_amount_in_eth_secondary).unwrap();
 				assert_eq!(
 					Currencies::free_balance(CurrencyId::METH, &ALICE),
 					expected_amount_wrapped_tokens_in_eth_summary
@@ -269,7 +270,7 @@ mod tests {
 					alice_borrowed_amount_in_dot
 				);
 				// Checking total borrow for DOT pool
-				let expected_borrow_interest_accumulated = 21779999999850000;
+				let expected_borrow_interest_accumulated = 421875000000000;
 				assert_eq!(
 					TestPools::pools(CurrencyId::DOT).total_borrowed,
 					alice_borrowed_amount_in_dot + expected_borrow_interest_accumulated
@@ -406,12 +407,13 @@ mod tests {
 	#[test]
 	fn redeem_underlying_with_third_currency_borrowing() {
 		ExtBuilder::default()
-			.user_balance(ALICE, CurrencyId::ETH, ONE_HUNDRED)
+			.pool_initial(CurrencyId::DOT)
+			.pool_initial(CurrencyId::ETH)
+			.user_balance(ADMIN, CurrencyId::ETH, ONE_HUNDRED)
 			.user_balance(ALICE, CurrencyId::DOT, ONE_HUNDRED)
 			.user_balance(ALICE, CurrencyId::BTC, ONE_HUNDRED)
 			.pool_user_data(CurrencyId::DOT, ALICE, BALANCE_ZERO, RATE_ZERO, true, 0)
 			.pool_user_data(CurrencyId::BTC, ALICE, BALANCE_ZERO, RATE_ZERO, true, 0)
-			.pool_balance(CurrencyId::DOT, BALANCE_ZERO)
 			.build()
 			.execute_with(|| {
 				// Set initial balance
@@ -562,20 +564,20 @@ mod tests {
 	#[test]
 	fn redeem_underlying_over_insurance() {
 		ExtBuilder::default()
+			.pool_initial(CurrencyId::DOT)
 			.user_balance(ADMIN, CurrencyId::DOT, ONE_HUNDRED)
 			.user_balance(ALICE, CurrencyId::DOT, ONE_HUNDRED)
 			.user_balance(BOB, CurrencyId::BTC, ONE_HUNDRED)
 			.user_balance(BOB, CurrencyId::DOT, ONE_HUNDRED)
 			.pool_user_data(CurrencyId::DOT, ALICE, BALANCE_ZERO, RATE_ZERO, false, 0)
 			.pool_user_data(CurrencyId::BTC, BOB, BALANCE_ZERO, RATE_ZERO, true, 0)
-			.pool_balance(CurrencyId::DOT, BALANCE_ZERO)
 			.build()
 			.execute_with(|| {
 				// Set initial balance
 				assert_ok!(MinterestProtocol::deposit_underlying(
 					Origin::signed(ADMIN),
 					CurrencyId::DOT,
-					ONE_HUNDRED
+					10_000 * DOLLARS
 				));
 
 				// Alice deposit to DOT pool

--- a/pallets/integration-tests/src/tests/minterest_protocol_tests.rs
+++ b/pallets/integration-tests/src/tests/minterest_protocol_tests.rs
@@ -8,12 +8,19 @@ mod tests {
 	#[test]
 	fn deposit_underlying_with_supplied_insurance_should_work() {
 		ExtBuilder::default()
+			.user_balance(ADMIN, CurrencyId::DOT, ONE_HUNDRED)
 			.user_balance(ALICE, CurrencyId::DOT, ONE_HUNDRED)
 			.user_balance(BOB, CurrencyId::DOT, ONE_HUNDRED)
 			.pool_user_data(CurrencyId::DOT, ALICE, BALANCE_ZERO, RATE_ZERO, false, 0)
-			.pool_total_insurance(CurrencyId::DOT, ONE_HUNDRED)
 			.build()
 			.execute_with(|| {
+				// Set initial balance
+				assert_ok!(MinterestProtocol::deposit_underlying(
+					Origin::signed(ADMIN),
+					CurrencyId::DOT,
+					ONE_HUNDRED
+				));
+
 				// Alice deposit to DOT pool
 				let alice_deposited_amount = 60_000 * DOLLARS;
 				assert_ok!(MinterestProtocol::deposit_underlying(
@@ -126,13 +133,20 @@ mod tests {
 	#[test]
 	fn redeem_underlying_with_current_currency_borrowing() {
 		ExtBuilder::default()
+			.user_balance(ADMIN, CurrencyId::DOT, ONE_HUNDRED)
 			.user_balance(ALICE, CurrencyId::DOT, ONE_HUNDRED)
 			.user_balance(ALICE, CurrencyId::ETH, ONE_HUNDRED)
 			.pool_user_data(CurrencyId::DOT, ALICE, BALANCE_ZERO, RATE_ZERO, true, 0)
 			.pool_user_data(CurrencyId::ETH, ALICE, BALANCE_ZERO, RATE_ZERO, true, 0)
-			.pool_total_insurance(CurrencyId::DOT, ONE_HUNDRED)
 			.build()
 			.execute_with(|| {
+				// Set initial balance
+				assert_ok!(MinterestProtocol::deposit_underlying(
+					Origin::signed(ADMIN),
+					CurrencyId::DOT,
+					ONE_HUNDRED
+				));
+
 				// Alice deposit 60 DOT to pool.
 				let alice_deposited_amount_in_dot = 60_000 * DOLLARS;
 				assert_ok!(MinterestProtocol::deposit_underlying(
@@ -287,13 +301,24 @@ mod tests {
 	#[test]
 	fn redeem_underlying_with_another_currency_borrowing() {
 		ExtBuilder::default()
+			.user_balance(ADMIN, CurrencyId::DOT, ONE_HUNDRED)
+			.user_balance(ADMIN, CurrencyId::ETH, ONE_HUNDRED)
 			.user_balance(ALICE, CurrencyId::DOT, ONE_HUNDRED)
 			.pool_user_data(CurrencyId::DOT, ALICE, BALANCE_ZERO, RATE_ZERO, true, 0)
 			.pool_balance(CurrencyId::DOT, BALANCE_ZERO)
-			.pool_total_insurance(CurrencyId::DOT, ONE_HUNDRED)
-			.pool_total_insurance(CurrencyId::ETH, ONE_HUNDRED)
 			.build()
 			.execute_with(|| {
+				// Set initial balance
+				assert_ok!(MinterestProtocol::deposit_underlying(
+					Origin::signed(ADMIN),
+					CurrencyId::DOT,
+					ONE_HUNDRED
+				));
+				assert_ok!(MinterestProtocol::deposit_underlying(
+					Origin::signed(ADMIN),
+					CurrencyId::ETH,
+					ONE_HUNDRED
+				));
 				// Alice deposit to DOT pool
 				let alice_deposited_amount_in_dot = 60_000 * DOLLARS;
 				assert_ok!(MinterestProtocol::deposit_underlying(
@@ -383,14 +408,21 @@ mod tests {
 	#[test]
 	fn redeem_underlying_with_third_currency_borrowing() {
 		ExtBuilder::default()
+			.user_balance(ALICE, CurrencyId::ETH, ONE_HUNDRED)
 			.user_balance(ALICE, CurrencyId::DOT, ONE_HUNDRED)
 			.user_balance(ALICE, CurrencyId::BTC, ONE_HUNDRED)
 			.pool_user_data(CurrencyId::DOT, ALICE, BALANCE_ZERO, RATE_ZERO, true, 0)
 			.pool_user_data(CurrencyId::BTC, ALICE, BALANCE_ZERO, RATE_ZERO, true, 0)
 			.pool_balance(CurrencyId::DOT, BALANCE_ZERO)
-			.pool_total_insurance(CurrencyId::ETH, ONE_HUNDRED)
 			.build()
 			.execute_with(|| {
+				// Set initial balance
+				assert_ok!(MinterestProtocol::deposit_underlying(
+					Origin::signed(ADMIN),
+					CurrencyId::ETH,
+					ONE_HUNDRED
+				));
+
 				// Alice deposit to DOT pool
 				let alice_deposited_amount_in_dot = 40_000 * DOLLARS;
 				assert_ok!(MinterestProtocol::deposit_underlying(
@@ -532,15 +564,22 @@ mod tests {
 	#[test]
 	fn redeem_underlying_over_insurance() {
 		ExtBuilder::default()
+			.user_balance(ADMIN, CurrencyId::DOT, ONE_HUNDRED)
 			.user_balance(ALICE, CurrencyId::DOT, ONE_HUNDRED)
 			.user_balance(BOB, CurrencyId::BTC, ONE_HUNDRED)
 			.user_balance(BOB, CurrencyId::DOT, ONE_HUNDRED)
 			.pool_user_data(CurrencyId::DOT, ALICE, BALANCE_ZERO, RATE_ZERO, false, 0)
 			.pool_user_data(CurrencyId::BTC, BOB, BALANCE_ZERO, RATE_ZERO, true, 0)
 			.pool_balance(CurrencyId::DOT, BALANCE_ZERO)
-			.pool_total_insurance(CurrencyId::DOT, 10_000 * DOLLARS)
 			.build()
 			.execute_with(|| {
+				// Set initial balance
+				assert_ok!(MinterestProtocol::deposit_underlying(
+					Origin::signed(ADMIN),
+					CurrencyId::DOT,
+					ONE_HUNDRED
+				));
+
 				// Alice deposit to DOT pool
 				let alice_deposited_amount_in_dot = 20_000 * DOLLARS;
 				assert_ok!(MinterestProtocol::deposit_underlying(
@@ -630,14 +669,21 @@ mod tests {
 	#[test]
 	fn redeem_with_current_currency_borrowing() {
 		ExtBuilder::default()
+			.user_balance(ADMIN, CurrencyId::DOT, ONE_HUNDRED)
 			.user_balance(ALICE, CurrencyId::DOT, ONE_HUNDRED)
 			.user_balance(ALICE, CurrencyId::ETH, ONE_HUNDRED)
 			.user_balance(BOB, CurrencyId::DOT, 100_000_000 * DOLLARS)
 			.pool_user_data(CurrencyId::DOT, ALICE, BALANCE_ZERO, RATE_ZERO, true, 0)
 			.pool_user_data(CurrencyId::ETH, ALICE, BALANCE_ZERO, RATE_ZERO, true, 0)
-			.pool_total_insurance(CurrencyId::DOT, ONE_HUNDRED)
 			.build()
 			.execute_with(|| {
+				// Set initial balance
+				assert_ok!(MinterestProtocol::deposit_underlying(
+					Origin::signed(ADMIN),
+					CurrencyId::DOT,
+					ONE_HUNDRED
+				));
+
 				// Alice deposit to DOT pool
 				let alice_deposited_amount_in_dot = 60_000 * DOLLARS;
 				assert_ok!(MinterestProtocol::deposit_underlying(
@@ -789,13 +835,24 @@ mod tests {
 	#[test]
 	fn redeem_with_another_currency_borrowing() {
 		ExtBuilder::default()
+			.user_balance(ADMIN, CurrencyId::DOT, ONE_HUNDRED)
+			.user_balance(ADMIN, CurrencyId::ETH, ONE_HUNDRED)
 			.user_balance(ALICE, CurrencyId::DOT, ONE_HUNDRED)
 			.pool_user_data(CurrencyId::DOT, ALICE, BALANCE_ZERO, RATE_ZERO, true, 0)
 			.pool_balance(CurrencyId::DOT, BALANCE_ZERO)
-			.pool_total_insurance(CurrencyId::DOT, ONE_HUNDRED)
-			.pool_total_insurance(CurrencyId::ETH, ONE_HUNDRED)
 			.build()
 			.execute_with(|| {
+				// Set initial balance
+				assert_ok!(MinterestProtocol::deposit_underlying(
+					Origin::signed(ADMIN),
+					CurrencyId::DOT,
+					ONE_HUNDRED
+				));
+				assert_ok!(MinterestProtocol::deposit_underlying(
+					Origin::signed(ADMIN),
+					CurrencyId::ETH,
+					ONE_HUNDRED
+				));
 				// Alice deposit to DOT pool
 				let alice_deposited_amount_in_dot = 60_000 * DOLLARS;
 				assert_ok!(MinterestProtocol::deposit_underlying(
@@ -881,14 +938,21 @@ mod tests {
 	#[test]
 	fn redeem_with_third_currency_borrowing() {
 		ExtBuilder::default()
+			.user_balance(ADMIN, CurrencyId::ETH, ONE_HUNDRED)
 			.user_balance(ALICE, CurrencyId::DOT, ONE_HUNDRED)
 			.user_balance(ALICE, CurrencyId::BTC, ONE_HUNDRED)
 			.pool_user_data(CurrencyId::DOT, ALICE, BALANCE_ZERO, RATE_ZERO, true, 0)
 			.pool_user_data(CurrencyId::BTC, ALICE, BALANCE_ZERO, RATE_ZERO, true, 0)
 			.pool_balance(CurrencyId::DOT, BALANCE_ZERO)
-			.pool_total_insurance(CurrencyId::ETH, ONE_HUNDRED)
 			.build()
 			.execute_with(|| {
+				// Set initial balance
+				assert_ok!(MinterestProtocol::deposit_underlying(
+					Origin::signed(ADMIN),
+					CurrencyId::ETH,
+					ONE_HUNDRED
+				));
+
 				// Alice deposit to DOT pool
 				let alice_deposited_amount_in_dot = 40_000 * DOLLARS;
 				assert_ok!(MinterestProtocol::deposit_underlying(
@@ -1019,7 +1083,6 @@ mod tests {
 			.pool_user_data(CurrencyId::DOT, BOB, BALANCE_ZERO, RATE_ZERO, false, 0)
 			.pool_user_data(CurrencyId::BTC, BOB, BALANCE_ZERO, RATE_ZERO, true, 0)
 			.pool_balance(CurrencyId::DOT, BALANCE_ZERO)
-			.pool_total_insurance(CurrencyId::DOT, 10_000 * DOLLARS)
 			.build()
 			.execute_with(|| {
 				// Alice deposit to DOT pool
@@ -1098,11 +1161,18 @@ mod tests {
 	#[test]
 	fn borrow_with_insufficient_collateral_no_deposits() {
 		ExtBuilder::default()
+			.user_balance(ADMIN, CurrencyId::DOT, ONE_HUNDRED)
 			.user_balance(ALICE, CurrencyId::DOT, ONE_HUNDRED)
 			.pool_user_data(CurrencyId::DOT, ALICE, BALANCE_ZERO, RATE_ZERO, true, 0)
-			.pool_total_insurance(CurrencyId::DOT, ONE_HUNDRED)
 			.build()
 			.execute_with(|| {
+				// Set initial balance
+				assert_ok!(MinterestProtocol::deposit_underlying(
+					Origin::signed(ADMIN),
+					CurrencyId::ETH,
+					ONE_HUNDRED
+				));
+
 				// Alice try to borrow from DOT pool
 				let alice_borrowed_amount_in_dot = 50_000 * DOLLARS;
 				assert_noop!(
@@ -1125,12 +1195,24 @@ mod tests {
 	#[test]
 	fn borrow_without_collateral_in_second_currency() {
 		ExtBuilder::default()
+			.user_balance(ADMIN, CurrencyId::DOT, ONE_HUNDRED)
+			.user_balance(ADMIN, CurrencyId::ETH, ONE_HUNDRED)
 			.user_balance(ALICE, CurrencyId::DOT, ONE_HUNDRED)
 			.pool_user_data(CurrencyId::DOT, ALICE, BALANCE_ZERO, RATE_ZERO, false, 0)
-			.pool_total_insurance(CurrencyId::DOT, ONE_HUNDRED)
-			.pool_total_insurance(CurrencyId::ETH, ONE_HUNDRED)
 			.build()
 			.execute_with(|| {
+				// Set initial balance
+				assert_ok!(MinterestProtocol::deposit_underlying(
+					Origin::signed(ADMIN),
+					CurrencyId::DOT,
+					ONE_HUNDRED
+				));
+				assert_ok!(MinterestProtocol::deposit_underlying(
+					Origin::signed(ADMIN),
+					CurrencyId::ETH,
+					ONE_HUNDRED
+				));
+
 				// Alice deposit to DOT pool
 				let alice_deposited_amount = 50_000 * DOLLARS;
 				assert_ok!(MinterestProtocol::deposit_underlying(
@@ -1167,12 +1249,23 @@ mod tests {
 	#[test]
 	fn borrow_with_insufficient_collateral_in_second_currency() {
 		ExtBuilder::default()
+			.user_balance(ADMIN, CurrencyId::DOT, ONE_HUNDRED)
+			.user_balance(ADMIN, CurrencyId::ETH, ONE_HUNDRED)
 			.user_balance(ALICE, CurrencyId::DOT, ONE_HUNDRED)
 			.pool_user_data(CurrencyId::DOT, ALICE, BALANCE_ZERO, RATE_ZERO, true, 0)
-			.pool_total_insurance(CurrencyId::DOT, ONE_HUNDRED)
-			.pool_total_insurance(CurrencyId::ETH, ONE_HUNDRED)
 			.build()
 			.execute_with(|| {
+				// Set initial balance
+				assert_ok!(MinterestProtocol::deposit_underlying(
+					Origin::signed(ADMIN),
+					CurrencyId::DOT,
+					ONE_HUNDRED
+				));
+				assert_ok!(MinterestProtocol::deposit_underlying(
+					Origin::signed(ADMIN),
+					CurrencyId::ETH,
+					ONE_HUNDRED
+				));
 				// Alice deposit to DOT pool
 				let alice_deposited_amount = 50_000 * DOLLARS;
 				assert_ok!(MinterestProtocol::deposit_underlying(
@@ -1209,12 +1302,23 @@ mod tests {
 	#[test]
 	fn borrow_with_sufficient_collateral_in_second_currency() {
 		ExtBuilder::default()
+			.user_balance(ADMIN, CurrencyId::DOT, ONE_HUNDRED)
+			.user_balance(ADMIN, CurrencyId::ETH, ONE_HUNDRED)
 			.user_balance(ALICE, CurrencyId::DOT, ONE_HUNDRED)
 			.pool_user_data(CurrencyId::DOT, ALICE, BALANCE_ZERO, RATE_ZERO, true, 0)
-			.pool_total_insurance(CurrencyId::DOT, ONE_HUNDRED)
-			.pool_total_insurance(CurrencyId::ETH, ONE_HUNDRED)
 			.build()
 			.execute_with(|| {
+				// Set initial balance
+				assert_ok!(MinterestProtocol::deposit_underlying(
+					Origin::signed(ADMIN),
+					CurrencyId::DOT,
+					ONE_HUNDRED
+				));
+				assert_ok!(MinterestProtocol::deposit_underlying(
+					Origin::signed(ADMIN),
+					CurrencyId::ETH,
+					ONE_HUNDRED
+				));
 				// Alice deposit to DOT pool
 				let alice_deposited_amount = 50_000 * DOLLARS;
 				assert_ok!(MinterestProtocol::deposit_underlying(

--- a/pallets/liquidation-pools/src/mock.rs
+++ b/pallets/liquidation-pools/src/mock.rs
@@ -74,7 +74,7 @@ impl orml_tokens::Trait for Test {
 }
 
 parameter_types! {
-	pub const GetNativeCurrencyId: CurrencyId = CurrencyId::MINT;
+	pub const GetNativeCurrencyId: CurrencyId = CurrencyId::MNT;
 }
 
 type NativeCurrency = Currency<Test, GetNativeCurrencyId>;

--- a/pallets/liquidity-pools/src/mock.rs
+++ b/pallets/liquidity-pools/src/mock.rs
@@ -88,7 +88,7 @@ impl orml_tokens::Trait for Test {
 }
 
 parameter_types! {
-	pub const GetNativeCurrencyId: CurrencyId = CurrencyId::MINT;
+	pub const GetNativeCurrencyId: CurrencyId = CurrencyId::MNT;
 }
 
 type NativeCurrency = Currency<Test, GetNativeCurrencyId>;

--- a/pallets/m-tokens/src/mock.rs
+++ b/pallets/m-tokens/src/mock.rs
@@ -75,7 +75,7 @@ impl orml_tokens::Trait for Runtime {
 }
 
 parameter_types! {
-	pub const GetNativeCurrencyId: CurrencyId = CurrencyId::MINT;
+	pub const GetNativeCurrencyId: CurrencyId = CurrencyId::MNT;
 }
 
 type NativeCurrency = Currency<Runtime, GetNativeCurrencyId>;
@@ -116,9 +116,9 @@ impl ExtBuilder {
 		self
 	}
 
-	pub fn one_million_mint_and_mdot_for_alice(self) -> Self {
+	pub fn one_million_mnt_and_mdot_for_alice(self) -> Self {
 		self.balances(vec![
-			(ALICE, CurrencyId::MINT, ONE_MILL),
+			(ALICE, CurrencyId::MNT, ONE_MILL),
 			(ALICE, CurrencyId::MDOT, ONE_MILL),
 		])
 	}

--- a/pallets/m-tokens/src/tests.rs
+++ b/pallets/m-tokens/src/tests.rs
@@ -38,7 +38,7 @@ fn approve_fails_if_overflow() {
 #[test]
 fn transfer_from_should_work() {
 	ExtBuilder::default()
-		.one_million_mint_and_mdot_for_alice()
+		.one_million_mnt_and_mdot_for_alice()
 		.build()
 		.execute_with(|| {
 			assert_ok!(MTokens::approve(Origin::signed(ALICE), BOB, CurrencyId::MDOT, 100));
@@ -80,7 +80,7 @@ fn transfer_from_fails_if_balance_too_low() {
 #[test]
 fn transfer_from_fails_if_allowance_does_not_exist() {
 	ExtBuilder::default()
-		.one_million_mint_and_mdot_for_alice()
+		.one_million_mnt_and_mdot_for_alice()
 		.build()
 		.execute_with(|| {
 			assert_ok!(MTokens::approve(Origin::signed(ALICE), BOB, CurrencyId::MDOT, 100));

--- a/pallets/minterest-protocol/src/mock.rs
+++ b/pallets/minterest-protocol/src/mock.rs
@@ -88,7 +88,7 @@ impl orml_tokens::Trait for Test {
 }
 
 parameter_types! {
-	pub const GetNativeCurrencyId: CurrencyId = CurrencyId::MINT;
+	pub const GetNativeCurrencyId: CurrencyId = CurrencyId::MNT;
 }
 
 type NativeCurrency = Currency<Test, GetNativeCurrencyId>;
@@ -182,11 +182,11 @@ impl Default for ExtBuilder {
 		Self {
 			endowed_accounts: vec![
 				// seed: initial DOTs. Initial MINT to pay for gas.
-				(ALICE, CurrencyId::MINT, ONE_MILL_DOLLARS),
+				(ALICE, CurrencyId::MNT, ONE_MILL_DOLLARS),
 				(ALICE, CurrencyId::DOT, ONE_HUNDRED_DOLLARS),
 				(ALICE, CurrencyId::ETH, ONE_HUNDRED_DOLLARS),
 				(ALICE, CurrencyId::KSM, ONE_HUNDRED_DOLLARS),
-				(BOB, CurrencyId::MINT, ONE_MILL_DOLLARS),
+				(BOB, CurrencyId::MNT, ONE_MILL_DOLLARS),
 				(BOB, CurrencyId::DOT, ONE_HUNDRED_DOLLARS),
 				// seed: initial insurance, equal 10_000$
 				(TestPools::pools_account_id(), CurrencyId::ETH, TEN_THOUSAND_DOLLARS),

--- a/pallets/minterest-protocol/src/tests.rs
+++ b/pallets/minterest-protocol/src/tests.rs
@@ -681,14 +681,14 @@ fn transfer_wrapped_should_work() {
 #[test]
 fn transfer_wrapped_should_not_work() {
 	ExtBuilder::default()
-		.user_balance(ALICE, CurrencyId::MINT, ONE_HUNDRED_DOLLARS)
+		.user_balance(ALICE, CurrencyId::MNT, ONE_HUNDRED_DOLLARS)
 		.user_balance(ALICE, CurrencyId::MDOT, ONE_HUNDRED_DOLLARS)
 		.user_balance(ALICE, CurrencyId::MKSM, ONE_HUNDRED_DOLLARS)
 		.build()
 		.execute_with(|| {
 			// Alice is unable to transfer more tokens tan she has
 			assert_noop!(
-				TestProtocol::transfer_wrapped(alice(), BOB, CurrencyId::MINT, ONE_HUNDRED_DOLLARS),
+				TestProtocol::transfer_wrapped(alice(), BOB, CurrencyId::MNT, ONE_HUNDRED_DOLLARS),
 				Error::<Test>::NotValidWrappedTokenId
 			);
 

--- a/pallets/oracle/src/lib.rs
+++ b/pallets/oracle/src/lib.rs
@@ -35,7 +35,7 @@ type PriceResult = result::Result<Price, DispatchError>;
 
 impl<T: Trait> Module<T> {
 	pub fn get_underlying_price(_underlying_asset_id: CurrencyId) -> PriceResult {
-		let price_nine_dollars = 2_00u128 * 10_000_000_000_000_000;
-		Ok(Price::from_inner(price_nine_dollars)) // Price = 2.00 USD
+		let price_two_dollars = 2_00u128 * 10_000_000_000_000_000;
+		Ok(Price::from_inner(price_two_dollars)) // Price = 2.00 USD
 	}
 }

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -48,7 +48,7 @@ pub type Price = FixedU128;
 #[derive(Encode, Decode, Eq, PartialEq, Copy, Clone, RuntimeDebug, PartialOrd, Ord)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub enum CurrencyId {
-	MINT = 0,
+	MNT = 0,
 	DOT,
 	KSM,
 	BTC,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -262,7 +262,7 @@ impl orml_tokens::Trait for Runtime {
 }
 
 parameter_types! {
-	pub const GetMinterestCurrencyId: CurrencyId = CurrencyId::MINT;
+	pub const GetMinterestCurrencyId: CurrencyId = CurrencyId::MNT;
 }
 
 pub type MinterestToken = BasicCurrencyAdapter<Runtime, Balances, Amount, BlockNumber>;

--- a/runtime/src/tests.rs
+++ b/runtime/src/tests.rs
@@ -36,13 +36,13 @@ impl Default for ExtBuilder {
 		Self {
 			endowed_accounts: vec![
 				// seed: initial assets. Initial MINT to pay for gas.
-				(ALICE::get(), CurrencyId::MINT, 100_000 * DOLLARS),
+				(ALICE::get(), CurrencyId::MNT, 100_000 * DOLLARS),
 				(ALICE::get(), CurrencyId::DOT, 100_000 * DOLLARS),
 				(ALICE::get(), CurrencyId::ETH, 100_000 * DOLLARS),
-				(BOB::get(), CurrencyId::MINT, 100_000 * DOLLARS),
+				(BOB::get(), CurrencyId::MNT, 100_000 * DOLLARS),
 				(BOB::get(), CurrencyId::DOT, 100_000 * DOLLARS),
 				(BOB::get(), CurrencyId::ETH, 100_000 * DOLLARS),
-				(CHARLIE::get(), CurrencyId::MINT, 100_000 * DOLLARS),
+				(CHARLIE::get(), CurrencyId::MNT, 100_000 * DOLLARS),
 				(CHARLIE::get(), CurrencyId::DOT, 100_000 * DOLLARS),
 				(CHARLIE::get(), CurrencyId::ETH, 100_000 * DOLLARS),
 			],

--- a/types.json
+++ b/types.json
@@ -4,7 +4,7 @@
     "LookupSource": "AccountId",
     "CurrencyId": {
       "_enum": [
-        "MINT",
+        "MNT",
         "DOT",
         "KSM",
         "BTC",


### PR DESCRIPTION
**Description:**

Removed method total_pool_insurance from integration tests.
Renamed MINT to MNT.
Fixed file types.json.

**Changes in storage:**

-

**Test scenarios/Use cases:**

If applicable, describe new use cases and leave @DenisRomanovsky  mention. 

The info will go to the Protocol documentation.

