### PR TITLE
Ep/be 38 fix bug in setters for minterest protocol params

### DIFF
--- a/pallets/minterest-model/src/lib.rs
+++ b/pallets/minterest-model/src/lib.rs
@@ -117,7 +117,7 @@ decl_module! {
 			let new_jump_multiplier_per_year = Rate::checked_from_rational(jump_multiplier_rate_per_year_n, jump_multiplier_rate_per_year_d)
 				.ok_or(Error::<T>::NumOverflow)?;
 			let new_jump_multiplier_per_block = new_jump_multiplier_per_year
-				.checked_div(&Rate::from_inner(T::BlocksPerYear::get()))
+				.checked_div(&Rate::saturating_from_rational(T::BlocksPerYear::get(), 1))
 				.ok_or(Error::<T>::NumOverflow)?;
 
 			// Write the previously calculated values into storage.
@@ -148,7 +148,7 @@ decl_module! {
 			let new_base_rate_per_year = Rate::checked_from_rational(base_rate_per_year_n, base_rate_per_year_d)
 				.ok_or(Error::<T>::NumOverflow)?;
 			let new_base_rate_per_block = new_base_rate_per_year
-				.checked_div(&Rate::from_inner(T::BlocksPerYear::get()))
+				.checked_div(&Rate::saturating_from_rational(T::BlocksPerYear::get(), 1))
 				.ok_or(Error::<T>::NumOverflow)?;
 
 			// Base rate per block cannot be set to 0 at the same time as Multiplier per block.
@@ -184,7 +184,7 @@ decl_module! {
 			let new_multiplier_per_year = Rate::checked_from_rational(multiplier_rate_per_year_n, multiplier_rate_per_year_d)
 				.ok_or(Error::<T>::NumOverflow)?;
 			let new_multiplier_per_block = new_multiplier_per_year
-				.checked_div(&Rate::from_inner(T::BlocksPerYear::get()))
+				.checked_div(&Rate::saturating_from_rational(T::BlocksPerYear::get(), 1))
 				.ok_or(Error::<T>::NumOverflow)?;
 
 			// Multiplier per block cannot be set to 0 at the same time as Base rate per block .

--- a/pallets/minterest-model/src/tests.rs
+++ b/pallets/minterest-model/src/tests.rs
@@ -26,7 +26,21 @@ fn base_rate_per_block_equal_max_value() -> MinterestModelData {
 #[test]
 fn set_base_rate_per_block_should_work() {
 	new_test_ext().execute_with(|| {
-		// Can be set to 0.0
+		// Set Base rate per block equal 2.0: (10_512_000 / 1) / 5_256_000
+		assert_ok!(TestMinterestModel::set_base_rate_per_block(
+			alice(),
+			CurrencyId::DOT,
+			10_512_000,
+			1
+		));
+		assert_eq!(
+			TestMinterestModel::minterest_model_dates(CurrencyId::DOT).base_rate_per_block,
+			Rate::saturating_from_rational(2, 1)
+		);
+		let expected_event = TestEvent::minterest_model(Event::BaseRatePerBlockHasChanged);
+		assert!(System::events().iter().any(|record| record.event == expected_event));
+
+		// Can be set to 0.0: (0 / 10) / 5_256_000
 		assert_ok!(TestMinterestModel::set_base_rate_per_block(
 			alice(),
 			CurrencyId::DOT,
@@ -35,24 +49,20 @@ fn set_base_rate_per_block_should_work() {
 		));
 		assert_eq!(
 			TestMinterestModel::minterest_model_dates(CurrencyId::DOT).base_rate_per_block,
-			Rate::from_inner(0)
+			Rate::zero()
 		);
-		let expected_event = TestEvent::minterest_model(Event::BaseRatePerBlockHasChanged);
-		assert!(System::events().iter().any(|record| record.event == expected_event));
 
-		// ALICE set Baser rate per block equal 2.0
+		// ALICE set Baser rate per block equal 0,000000009: (47_304 / 1_000_000) / 5_256_000
 		assert_ok!(TestMinterestModel::set_base_rate_per_block(
 			alice(),
 			CurrencyId::DOT,
-			20,
-			10
+			47304,
+			1_000_000
 		));
 		assert_eq!(
 			TestMinterestModel::minterest_model_dates(CurrencyId::DOT).base_rate_per_block,
-			Rate::saturating_from_rational(2_000_000_000_000_000_000u128, BLOCKS_PER_YEAR)
+			Rate::from_inner(9_000_000_000)
 		);
-		let expected_event = TestEvent::minterest_model(Event::BaseRatePerBlockHasChanged);
-		assert!(System::events().iter().any(|record| record.event == expected_event));
 
 		// Base rate per block cannot be set to 0 at the same time as Multiplier per block.
 		assert_ok!(TestMinterestModel::set_multiplier_per_block(
@@ -89,15 +99,27 @@ fn set_base_rate_per_block_should_work() {
 #[test]
 fn set_multiplier_per_block_should_work() {
 	new_test_ext().execute_with(|| {
-		// Set Base rate per block equal 2.0
+		// Set Multiplier per block equal 2.0: (10_512_000 / 1) / 5_256_000
+		assert_ok!(TestMinterestModel::set_multiplier_per_block(
+			alice(),
+			CurrencyId::DOT,
+			10_512_000,
+			1
+		));
+		assert_eq!(
+			TestMinterestModel::minterest_model_dates(CurrencyId::DOT).multiplier_per_block,
+			Rate::saturating_from_rational(2, 1)
+		);
+		let expected_event = TestEvent::minterest_model(Event::MultiplierPerBlockHasChanged);
+		assert!(System::events().iter().any(|record| record.event == expected_event));
+
+		// Can be set to 0.0 if Base rate per block grater than zero: (0 / 10) / 5_256_000
 		assert_ok!(TestMinterestModel::set_base_rate_per_block(
 			alice(),
 			CurrencyId::DOT,
-			20,
-			10
+			1,
+			1
 		));
-
-		// Can be set to 0.0
 		assert_ok!(TestMinterestModel::set_multiplier_per_block(
 			alice(),
 			CurrencyId::DOT,
@@ -106,23 +128,19 @@ fn set_multiplier_per_block_should_work() {
 		));
 		assert_eq!(
 			TestMinterestModel::minterest_model_dates(CurrencyId::DOT).multiplier_per_block,
-			Rate::from_inner(0)
+			Rate::zero()
 		);
-		let expected_event = TestEvent::minterest_model(Event::MultiplierPerBlockHasChanged);
-		assert!(System::events().iter().any(|record| record.event == expected_event));
 
-		// Alice set Multiplier per block equal 2.0 / 5_256_000
+		// Alice set Multiplier per block equal 0,000_000_009: (47_304 / 1_000_000) / 5_256_000
 		assert_ok!(TestMinterestModel::set_multiplier_per_block(
 			alice(),
 			CurrencyId::DOT,
-			20,
-			10
+			47304,
+			1_000_000
 		));
-		let expected_event = TestEvent::minterest_model(Event::MultiplierPerBlockHasChanged);
-		assert!(System::events().iter().any(|record| record.event == expected_event));
 		assert_eq!(
 			TestMinterestModel::minterest_model_dates(CurrencyId::DOT).multiplier_per_block,
-			Rate::saturating_from_rational(2_000_000_000_000_000_000u128, BLOCKS_PER_YEAR)
+			Rate::from_inner(9_000_000_000)
 		);
 
 		//  Multiplier per block cannot be set to 0 at the same time as Base rate per block.
@@ -160,18 +178,43 @@ fn set_multiplier_per_block_should_work() {
 #[test]
 fn set_jump_multiplier_per_block_should_work() {
 	new_test_ext().execute_with(|| {
+		// Set Jump multiplier per block equal 2.0: (10_512_000 / 1) / 5_256_000
 		assert_ok!(TestMinterestModel::set_jump_multiplier_per_block(
 			alice(),
 			CurrencyId::DOT,
-			20,
+			10_512_000,
+			1
+		));
+		assert_eq!(
+			TestMinterestModel::minterest_model_dates(CurrencyId::DOT).jump_multiplier_per_block,
+			Rate::saturating_from_rational(2, 1)
+		);
+		let expected_event = TestEvent::minterest_model(Event::JumpMultiplierPerBlockHasChanged);
+		assert!(System::events().iter().any(|record| record.event == expected_event));
+
+		// Can be set to 0.0: (0 / 10) / 5_256_000
+		assert_ok!(TestMinterestModel::set_jump_multiplier_per_block(
+			alice(),
+			CurrencyId::DOT,
+			0,
 			10
 		));
 		assert_eq!(
 			TestMinterestModel::minterest_model_dates(CurrencyId::DOT).jump_multiplier_per_block,
-			Rate::saturating_from_rational(2_000_000_000_000_000_000u128, BLOCKS_PER_YEAR)
+			Rate::zero()
 		);
-		let expected_event = TestEvent::minterest_model(Event::JumpMultiplierPerBlockHasChanged);
-		assert!(System::events().iter().any(|record| record.event == expected_event));
+
+		// Alice set Jump multiplier per block equal 0,000_000_009: (47_304 / 1_000_000) / 5_256_000
+		assert_ok!(TestMinterestModel::set_jump_multiplier_per_block(
+			alice(),
+			CurrencyId::DOT,
+			47_304,
+			1_000_000
+		));
+		assert_eq!(
+			TestMinterestModel::minterest_model_dates(CurrencyId::DOT).jump_multiplier_per_block,
+			Rate::from_inner(9_000_000_000)
+		);
 
 		// Overflow in calculation: 20 / 0
 		assert_noop!(

--- a/runtime/src/constants.rs
+++ b/runtime/src/constants.rs
@@ -23,8 +23,7 @@ pub mod time {
 	pub const HOURS: BlockNumber = MINUTES * 60;
 	pub const DAYS: BlockNumber = HOURS * 24;
 
-	pub const SECONDS_PER_YEAR: u128 = 365 * DAYS as u128;
-	pub const BLOCKS_PER_YEAR: u128 = SECONDS_PER_YEAR / MILLISECS_PER_BLOCK as u128;
+	pub const BLOCKS_PER_YEAR: u128 = 365 * DAYS as u128;
 	// BLOCKS_PER_YEAR has to be 5256000
 }
 


### PR DESCRIPTION
**Description:**

Fix BlocksPerYears const calculation. 
Fix fns set_jump_multiplier_per_block && set_base_rate_per_block && set_multiplier_per_block in minterest-model pallet.
Fix tests for this fns.

